### PR TITLE
last minute web animations fixes

### DIFF
--- a/scenes/briefing/js/clock.js
+++ b/scenes/briefing/js/clock.js
@@ -83,7 +83,7 @@ app.Clock.prototype.spinPointers_ = function() {
 
   var secondsEl = this.$secondsPointer.get(0);
   var secondsTransform = app.shared.utils.computedTransform(secondsEl);
-  secondsEl.animate([
+  var secondsAnim = secondsEl.animate([
     {transform: 'rotate(' + secondsTransform.rotate + 'deg)'},
     {transform: 'rotate(' + (secondsTransform.rotate + (360 * 2.5)) + 'deg)'}
   ], {duration: 1250, easing: 'ease-out'});
@@ -91,6 +91,13 @@ app.Clock.prototype.spinPointers_ = function() {
   // Offset the background animation by the interactive animation's length: at
   // 1.25 seconds back (animation time) plus 30 seconds (half offset).
   this.secondsPlayer_.currentTime += (-1.25 + 30) * 1000;
+
+  // NOTE: Works around compositor issue in Chrome 41, as two animations are
+  // running over secondsEl. Safe in 42+.
+  app.shared.utils.onWebAnimationFinished(secondsAnim, function() {
+    this.secondsPlayer_.pause();
+    this.secondsPlayer_.play();
+  }.bind(this));
 
   var sharedTiming = {duration: 500, easing: 'ease-out'};
 

--- a/scenes/briefing/js/sleepy.js
+++ b/scenes/briefing/js/sleepy.js
@@ -139,14 +139,14 @@ app.Sleepy.prototype.wakeUp_ = function() {
   this.stopSleepingKeyframes_();
 
   if (this.headRotateYPlayer !== null) {
-    this.headRotateYPlayer.reverse();
     this.headRotateYPlayer.playbackRate = -1.5;
+    this.headRotateYPlayer.play();
     this.headRotateYPlayer = null;
   }
 
   if (this.headRotateZPlayer !== null) {
-    this.headRotateZPlayer.reverse();
     this.headRotateZPlayer.playbackRate = -2.5;
+    this.headRotateZPlayer.play();
     this.headRotateZPlayer = null;
   }
 

--- a/scenes/briefing/js/sleepy.js
+++ b/scenes/briefing/js/sleepy.js
@@ -138,23 +138,16 @@ app.Sleepy.prototype.wakeUp_ = function() {
 
   this.stopSleepingKeyframes_();
 
-  if (this.sleepingVertically && this.headRotateYPlayer !== null) {
+  if (this.headRotateYPlayer !== null) {
+    this.headRotateYPlayer.reverse();
+    this.headRotateYPlayer.playbackRate = -1.5;
+    this.headRotateYPlayer = null;
+  }
 
-    this.headRotateYPlayer.playbackRate = -0.02;
-
-    app.shared.utils.onWebAnimationFinished(this.headRotateYPlayer, function() {
-      this.headRotateYPlayer.cancel();
-      this.headRotateYPlayer = null;
-    }.bind(this));
-
-  } else if (this.headRotateZPlayer !== null) {
-
-    this.headRotateZPlayer.playbackRate = -5;
-    app.shared.utils.onWebAnimationFinished(this.headRotateZPlayer, function() {
-      this.headRotateZPlayer.cancel();
-      this.headRotateZPlayer = null;
-    }.bind(this));
-
+  if (this.headRotateZPlayer !== null) {
+    this.headRotateZPlayer.reverse();
+    this.headRotateZPlayer.playbackRate = -2.5;
+    this.headRotateZPlayer = null;
   }
 
   window.santaApp.fire('sound-trigger', 'briefing_wakeup');
@@ -213,34 +206,28 @@ app.Sleepy.prototype.stopSleepingKeyframes_ = function() {
  * @private
  */
 app.Sleepy.prototype.tweenRotateYHead_ = function() {
-
   var duration = 70;
-
-  // TODO: Issues playing in reverse.
 
   var steps = [
     new Animation(this.$head.get(0), [
       {visibility: 'visible'},
       {visibility: 'hidden'}
     ], {duration: duration, fill: 'forwards'}),
-    
     new Animation(this.$headVerticalStep1.get(0), [
       {visibility: 'visible'},
       {visibility: 'hidden'}
-    ], {duration: duration, fill: 'none'}),
-
+    ], {duration: duration}),
     new Animation(this.$headVerticalStep2.get(0), [
       {visibility: 'visible'},
       {visibility: 'hidden'}
-    ], {duration: duration, fill: 'none'}),
-
+    ], {duration: duration}),
     new Animation(this.$headVerticalFinal.get(0), [
-      {visibility: 'visible'},  // forces last element to remain visible
+      {visibility: 'visible'},
       {visibility: 'visible'}
-    ], {duration: duration, easing: 'step-final', fill: 'fowards'})
+    ], {duration: duration, fill: 'forwards'}),
   ];
 
-  this.headRotateYPlayer = document.timeline.play(new AnimationSequence(steps, { fill: 'forwards' }));
+  this.headRotateYPlayer = document.timeline.play(new AnimationSequence(steps, {fill: 'forwards'}));
 };
 
 /**


### PR DESCRIPTION
Inside the briefing scene, the elf leaning back would show different positions of its head at the same time (they were all being set to `visibility: visible`). Removes some easing magic and adds an explicit `play()` call after setting the `playbackRate`, otherwise the animation wasn't necessarily played (since it was in the pause state).

Also fixes up some issues with `FauxTimeline` and a Chrome 41-only issue with double animations on `transform` (aka, a composited property).