### PR TITLE
Adding a clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ $ npm install
 
 Build with `gulp`. Alternatively, you can rebuild just the scenes with `gulp compile-scenes`, or the CSS with `gulp compass`.
 
+```bash
+$ npm install gulp    # Only required if you don't have gulp installed.
+$ gulp
+```
+
 The raw site can now be served from the root directory.
 
 ## Release


### PR DESCRIPTION
Adding notes about installing gulp.

Even with this change I'm still seeing a build failure:

```bash
brettmorgan@brettmorgan-macbookpro2 ~/github/santa-tracker-web$ gulp
module.js:338
    throw err;
          ^
Error: Cannot find module 'gulp-util'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/brettmorgan/github/santa-tracker-web/gulpfile.js:20:13)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```