### PR TITLE
Updates closure to include strictMissingProperties

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "browser-sync": "^2.9.12",
     "crisper": "^2.0.2",
     "del": "^2.0.2",
-    "google-closure-compiler": "^20161024.0.0",
+    "google-closure-compiler": "^20180805.0.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-changed": "^1.3.0",


### PR DESCRIPTION
A fresh git clone && npm install fails with an error about an unknown argument to @suppress, `strictMissingProperties`. This was added in v20180204.