### PR TITLE
allow tapping behind header

### DIFF
--- a/static/src/elements/santa-chrome.scss
+++ b/static/src/elements/santa-chrome.scss
@@ -42,6 +42,7 @@ $transition-toolbar: $duration-toolbar ease-in-out;
   padding-top: var(--padding-top, env(safe-area-inset-top, 0px));
   padding-left: var(--padding-side, env(safe-area-inset-left, 0px));
   padding-right: var(--padding-side, env(safe-area-inset-right, 0px));
+  pointer-events: none;
 }
 
 header {


### PR DESCRIPTION
On games like presentbounce, you often couldn't tap the "go" button on mobile because it was behind the header.