### PR TITLE
don't forward keydown events from keyboard, just focus

### DIFF
--- a/static/src/core/keys.js
+++ b/static/src/core/keys.js
@@ -53,17 +53,15 @@ export default function configureCustomKeys(loaderElement) {
   });
 
   document.body.addEventListener('keydown', (ev) => {
-    // Steal gameplay key events from the host frame and focus on the loader. Dispatch a fake event
-    // to the scene so that the keyboard feels fluid.
+    // Notice gameplay key events from the host frame and focus on the loader.
     const code = keycodeMap[ev.key];
     if (!code) {
       return false;  // not part of map, just ignore
     }
 
-    const {control} = global.getState();
-    if (control) {
-      control.send({type: 'keydown', payload: {key: ev.key, keyCode: code}});
-    }
+    // We used to dispatch a fake event to the scene so that the keyboard feels fluid, but we never
+    // followed up with keydown so it caused a bunch of problems.
+    // We do this in the gamepad handler, but ALL input is assumed to be coming from the gamepad.
     ev.preventDefault();
     loaderElement.focus();
   });

--- a/static/src/elements/santa-gameloader.js
+++ b/static/src/elements/santa-gameloader.js
@@ -268,6 +268,19 @@ class SantaGameLoaderElement extends HTMLElement {
   }
 
   /**
+   * We override focus to actually focus on the activeFrame. This is used to (hopefully) push
+   * keyboard events there.
+   *
+   * @override
+   */
+  focus() {
+    super.focus();
+    if (this._activeFrame) {
+      this._activeFrame.focus();
+    }
+  }
+
+  /**
    * Load a new scene.
    *
    * @param {?string} href
@@ -340,6 +353,9 @@ class SantaGameLoaderElement extends HTMLElement {
     // Success: the frame has reported ready. The following code is entirely non-async, and just
     // cleans up state as the scene is now active and happy.
     this._previousFrameClose();
+
+    // Try to focus the frame so default keyboard input goes here.
+    frame.focus();
 
     // Clean up CSS classes set during load.
     frame.classList.remove('pending');


### PR DESCRIPTION
We had a lot of reports of keyboard input not working. Those users probably remained focused on the outer frame.

Instead, disable the behavior which forwarded keyboard input from the top frame, and more aggressively call `focus()` on the inner frame.