### PR TITLE
don't trust http referrer

### DIFF
--- a/static/src/core/loader.js
+++ b/static/src/core/loader.js
@@ -35,6 +35,7 @@ function urlFor(sceneName, fallback, route, hash) {
     params.set('fallback', '1');
   }
   params.set('route', route);
+  params.set('referrer', window.location.origin + window.location.pathname);
   const p = `?${params.toString()}`;
   return join(import.meta.url, '../../scenes', sceneName, trailingIndex) + p + (hash || '');
 }

--- a/static/src/core/router.js
+++ b/static/src/core/router.js
@@ -302,7 +302,7 @@ export function globalClickHandler(scope, go) {
       return false;
     }
 
-    // TODO(samthor): This eats "#foo" links. That's probably fine.
+    // TODO(samthor): This eats "#foo" links to other pages. That's probably fine.
 
     const data = params.read(target.search);
     go(matchScene[1] || '', data);

--- a/static/src/scene/route.js
+++ b/static/src/scene/route.js
@@ -21,12 +21,28 @@
  * TODO: can also be used by prod.
  */
 
+function guessProdUrl() {
+  let params;
+  try {
+    // Scenes are passed this param in referrer=.
+    params = new URLSearchParams(window.location.search);
+  } catch (e) {
+    // ignore
+  }
+  if (params && params.has('referrer')) {
+    return params.get('referrer');
+  }
+  return document.referrer;
+}
+
 function determine() {
-  if (window.top != window && document.referrer) {
-    const scope = new URL('./', document.referrer);
+  const referrer = guessProdUrl();
+
+  if (window.top != window && referrer) {
+    const scope = new URL('./', referrer);
     return {
       scope: scope.toString(),
-      page: document.referrer,
+      page: referrer,
     };
   }
   const scope = new URL('./', window.location);


### PR DESCRIPTION
Fixes #38.

Safari doesn't want to send referrer with pathname even if we tell it it's okay; turns out we can just pass it as part of the URL.