### PR TITLE
Fix the map quiz game not working.

### DIFF
--- a/static/src/deps/maps.js
+++ b/static/src/deps/maps.js
@@ -26,6 +26,11 @@ function mapsApiURL() {
   const params = {
     'callback': callbackName,
     'key': apiKey,
+    // To keep things relatively stable, use quarterly version.
+    // See https://developers.google.com/maps/documentation/javascript/versions
+    'v': 'quarterly',
+    // Required for the map quiz game (/mercator.html)
+    'libraries': 'drawing,geometry',
   };
   if (document.documentElement.lang) {
     params['language'] = document.documentElement.lang;


### PR DESCRIPTION
This commit that changed the maps API also removed the library parameter
that was required to run the game:
https://github.com/google/santa-tracker-web/commit/8054be39c8a84f95e4cfcd46f4e2a13f1401a5ed

I added it back, along with the version tag too to use the more stable
version.

Tested by building locally, confirmed it wasn't working before and now
works after adding the tags. Will commit this now and then check that
everything is all good in staging.