### PR TITLE
Increase timeout for cloud builds

### DIFF
--- a/.cloudbuild/staging-deploy.yaml
+++ b/.cloudbuild/staging-deploy.yaml
@@ -32,3 +32,5 @@ options:
   env:
   - 'PROJECT_ID=$PROJECT_ID'
   - 'NODE_OPTIONS="--max-old-space-size=32768"'
+
+timeout: 1800s


### PR DESCRIPTION
Bump up the timeout length to 30 minutes.