### PR TITLE
chore: upgrade closure compiler and update compilation args

### DIFF
--- a/build/compile-scene.js
+++ b/build/compile-scene.js
@@ -41,7 +41,6 @@ const CLOSURE_DISABLE_WARNINGS = [
   'missingSourcesWarnings',
   'extraRequire',
   'missingProvide',
-  'strictMissingRequire',
   'missingRequire',
 ];
 
@@ -130,7 +129,7 @@ module.exports = async function compile(sceneName, compile=true) {
     externs: EXTERNS,
     create_source_map: sourceMapTemp.name,
     assume_function_wrapper: true,
-    dependency_mode: 'STRICT',  // ignore all but exported via _globalExportEntry, below
+    dependency_mode: 'PRUNE',  // ignore all but exported via _globalExportEntry, below
     entry_point: '_globalExportEntry',
     compilation_level: compile ? 'SIMPLE_OPTIMIZATIONS' : 'WHITESPACE_ONLY',
     warning_level: 'VERBOSE',

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fast-async": "^6.3.8",
     "firebase": "^8.10.0",
     "git-last-commit": "^1.0.1",
-    "google-closure-compiler": "^20190909.0.0",
+    "google-closure-compiler": "^20220719.0.0",
     "google-closure-library": "^20190909.0.0",
     "html-entities": "^1.2.1",
     "html-minifier": "^4.0.0",


### PR DESCRIPTION
For some reason, I can't pull and use the native compiler on my Mac unless we upgrade the google-closure-compiler dependency, and to get it to compile without errors, we need to account for a few breaking changes:
- The `STRICT` dependency mode has been changed to `PRUNE` (https://github.com/google/closure-compiler/issues/3534)
- The `strictMissingRequire` flag has been removed (https://github.com/google/closure-compiler/wiki/Releases#february-2-2021-v20210202)

Possibly fixes #96