### PR TITLE
Revert closure compiler to older version (reverts #97, #101)

### DIFF
--- a/build/compile-scene.js
+++ b/build/compile-scene.js
@@ -41,6 +41,7 @@ const CLOSURE_DISABLE_WARNINGS = [
   'missingSourcesWarnings',
   'extraRequire',
   'missingProvide',
+  'strictMissingRequire',
   'missingRequire',
 ];
 
@@ -129,7 +130,7 @@ module.exports = async function compile(sceneName, compile=true) {
     externs: EXTERNS,
     create_source_map: sourceMapTemp.name,
     assume_function_wrapper: true,
-    dependency_mode: 'PRUNE',  // ignore all but exported via _globalExportEntry, below
+    dependency_mode: 'STRICT',  // ignore all but exported via _globalExportEntry, below
     entry_point: '_globalExportEntry',
     compilation_level: compile ? 'SIMPLE_OPTIMIZATIONS' : 'WHITESPACE_ONLY',
     warning_level: 'VERBOSE',

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "fast-async": "^6.3.8",
         "firebase": "^8.10.0",
         "git-last-commit": "^1.0.1",
-        "google-closure-compiler": "^20220719.0.0",
+        "google-closure-compiler": "^20190909.0.0",
         "google-closure-library": "^20190909.0.0",
         "html-entities": "^1.2.1",
         "html-minifier": "^4.0.0",
@@ -3656,12 +3656,14 @@
       }
     },
     "node_modules/google-closure-compiler": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20220719.0.0.tgz",
-      "integrity": "sha512-0KTxUoX8WBZGeprvZfzp+czdi6wJ5wfJnG4RsIMEPFLR67fW4f+ghh04WSBLBt8kgT64NxaZGESjq23v0dbYNg==",
+      "version": "20190909.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20190909.0.0.tgz",
+      "integrity": "sha512-Mh1IKgp72HBgEeWQ5RDZHGj0w3vhEJsIaWptqSWEr7muinBv/0Xq5g1pxCvXX7LPfSH7vL+1Indzt1OxwfTXwQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "chalk": "2.x",
-        "google-closure-compiler-java": "^20220719.0.0",
+        "google-closure-compiler-java": "^20190909.0.0",
+        "google-closure-compiler-js": "^20190909.0.0",
         "minimist": "1.x",
         "vinyl": "2.x",
         "vinyl-sourcemaps-apply": "^0.2.0"
@@ -3670,56 +3672,38 @@
         "google-closure-compiler": "cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
       },
       "optionalDependencies": {
-        "google-closure-compiler-linux": "^20220719.0.0",
-        "google-closure-compiler-osx": "^20220719.0.0",
-        "google-closure-compiler-windows": "^20220719.0.0"
+        "google-closure-compiler-linux": "^20190909.0.0",
+        "google-closure-compiler-osx": "^20190909.0.0",
+        "google-closure-compiler-windows": "^20190909.0.0"
       }
     },
     "node_modules/google-closure-compiler-java": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20220719.0.0.tgz",
-      "integrity": "sha512-tjWdQSkFqxaFCgzUBaiJj2CxrWUYV0Ij2txp9Um+GyvrzMeX9rqHSUeW4I9cGpOrXkamvWCyAig4Yi0NZXApdg=="
+      "version": "20190909.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20190909.0.0.tgz",
+      "integrity": "sha512-Cz58+hW7XxFQ8KHenfP9eH2FqvGJ1ikcSebHihgqAg1Pfy8ZzxWUBZYEwOGqV0Kzcbb1NN79n0UMd2ZNfWb19w==",
+      "license": "Apache-2.0"
     },
-    "node_modules/google-closure-compiler-linux": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20220719.0.0.tgz",
-      "integrity": "sha512-Em8QEAH7RC8T41QgTZC2keO0gsNdQgburXuXoF6gv2ySD/kJvNqrlZCCqLZMZUF6iuCpu3PgnMahdd3IrLpprA==",
+    "node_modules/google-closure-compiler-js": {
+      "version": "20190909.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20190909.0.0.tgz",
+      "integrity": "sha512-x8PcAL5H5VxkOJ/jYdAYxwdwbIvClGW7IxzyOH2NMvBNVP6AbpJ24SCODQSA0qhMbCs45JyY3TJ9s2wH2NuzUA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/google-closure-compiler-osx": {
+      "version": "20190909.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20190909.0.0.tgz",
+      "integrity": "sha512-DvIr6gd7BfIpptSfLihEGwCHKlcwssHC+pt1duagRPfmgezp8GeJvAvbZIS/+Ud77zRFz+wcwQWsTvwyZSwklQ==",
       "cpu": [
         "x64",
         "x86"
       ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/google-closure-compiler-osx": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20220719.0.0.tgz",
-      "integrity": "sha512-NwOLgq0ftq0kY1jum6vrafwUMQrCJEpJu6wv5fW/TnYUprPJb1J0T7c4Su8wSm9rdvpqkkqWWMGpfb9RJBuM0g==",
-      "cpu": [
-        "x64",
-        "x86",
-        "arm64"
-      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/google-closure-compiler-windows": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20220719.0.0.tgz",
-      "integrity": "sha512-Qi88lkU7a45SzCwdd9CV1D6paiiF7cEpBefkJIaNKi9MBfOZueHZH7Y8/56rdMhJLRjv5VMCGoJY4xH6FcXkvg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/google-closure-library": {
@@ -9586,41 +9570,35 @@
       }
     },
     "google-closure-compiler": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20220719.0.0.tgz",
-      "integrity": "sha512-0KTxUoX8WBZGeprvZfzp+czdi6wJ5wfJnG4RsIMEPFLR67fW4f+ghh04WSBLBt8kgT64NxaZGESjq23v0dbYNg==",
+      "version": "20190909.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20190909.0.0.tgz",
+      "integrity": "sha512-Mh1IKgp72HBgEeWQ5RDZHGj0w3vhEJsIaWptqSWEr7muinBv/0Xq5g1pxCvXX7LPfSH7vL+1Indzt1OxwfTXwQ==",
       "requires": {
         "chalk": "2.x",
-        "google-closure-compiler-java": "^20220719.0.0",
-        "google-closure-compiler-linux": "^20220719.0.0",
-        "google-closure-compiler-osx": "^20220719.0.0",
-        "google-closure-compiler-windows": "^20220719.0.0",
+        "google-closure-compiler-java": "^20190909.0.0",
+        "google-closure-compiler-js": "^20190909.0.0",
+        "google-closure-compiler-linux": "^20190909.0.0",
+        "google-closure-compiler-osx": "^20190909.0.0",
+        "google-closure-compiler-windows": "^20190909.0.0",
         "minimist": "1.x",
         "vinyl": "2.x",
         "vinyl-sourcemaps-apply": "^0.2.0"
       }
     },
     "google-closure-compiler-java": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20220719.0.0.tgz",
-      "integrity": "sha512-tjWdQSkFqxaFCgzUBaiJj2CxrWUYV0Ij2txp9Um+GyvrzMeX9rqHSUeW4I9cGpOrXkamvWCyAig4Yi0NZXApdg=="
+      "version": "20190909.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20190909.0.0.tgz",
+      "integrity": "sha512-Cz58+hW7XxFQ8KHenfP9eH2FqvGJ1ikcSebHihgqAg1Pfy8ZzxWUBZYEwOGqV0Kzcbb1NN79n0UMd2ZNfWb19w=="
     },
-    "google-closure-compiler-linux": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20220719.0.0.tgz",
-      "integrity": "sha512-Em8QEAH7RC8T41QgTZC2keO0gsNdQgburXuXoF6gv2ySD/kJvNqrlZCCqLZMZUF6iuCpu3PgnMahdd3IrLpprA==",
-      "optional": true
+    "google-closure-compiler-js": {
+      "version": "20190909.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20190909.0.0.tgz",
+      "integrity": "sha512-x8PcAL5H5VxkOJ/jYdAYxwdwbIvClGW7IxzyOH2NMvBNVP6AbpJ24SCODQSA0qhMbCs45JyY3TJ9s2wH2NuzUA=="
     },
     "google-closure-compiler-osx": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20220719.0.0.tgz",
-      "integrity": "sha512-NwOLgq0ftq0kY1jum6vrafwUMQrCJEpJu6wv5fW/TnYUprPJb1J0T7c4Su8wSm9rdvpqkkqWWMGpfb9RJBuM0g==",
-      "optional": true
-    },
-    "google-closure-compiler-windows": {
-      "version": "20220719.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20220719.0.0.tgz",
-      "integrity": "sha512-Qi88lkU7a45SzCwdd9CV1D6paiiF7cEpBefkJIaNKi9MBfOZueHZH7Y8/56rdMhJLRjv5VMCGoJY4xH6FcXkvg==",
+      "version": "20190909.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20190909.0.0.tgz",
+      "integrity": "sha512-DvIr6gd7BfIpptSfLihEGwCHKlcwssHC+pt1duagRPfmgezp8GeJvAvbZIS/+Ud77zRFz+wcwQWsTvwyZSwklQ==",
       "optional": true
     },
     "google-closure-library": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fast-async": "^6.3.8",
     "firebase": "^8.10.0",
     "git-last-commit": "^1.0.1",
-    "google-closure-compiler": "^20220719.0.0",
+    "google-closure-compiler": "^20190909.0.0",
     "google-closure-library": "^20190909.0.0",
     "html-entities": "^1.2.1",
     "html-minifier": "^4.0.0",


### PR DESCRIPTION
Looks like something about the new version of the closure compiler doesn't work with Santa Tracker. Haven't gone through to debug the problem yet, but rolling this back for the moment so that we can push new releases