### PR TITLE
Remove the chromecast logic.

### DIFF
--- a/static/entrypoint.js
+++ b/static/entrypoint.js
@@ -37,7 +37,6 @@ import './src/elements/santa-tutorial.js';
 import './src/elements/santa-orientation.js';
 import './src/elements/santa-interlude.js';
 import {localStorage} from './src/storage.js';
-import maybeLoadCast from './src/deps/cast.js';
 import * as kplay from './src/kplay.js';
 import {buildLoader} from './src/core/loader.js';
 import {configureProdRouter, globalClickHandler} from './src/core/router.js';
@@ -52,9 +51,6 @@ import {_msg} from './src/magic.js';
 
 
 window.santaApp = {};
-
-
-maybeLoadCast();
 
 
 const noticesElement = document.createElement('div');


### PR DESCRIPTION
Casting is quite buggy, usually crashing chromecast devices in a few minutes. The page it casts is out of date too, still showing masks.

Removing it allows the default casting experience, which usually mirrors the page directly from the casting device.

We can revisit in the future :)