### PR TITLE
Fix color space

### DIFF
--- a/static/scenes/railroad/js/game.js
+++ b/static/scenes/railroad/js/game.js
@@ -27,7 +27,6 @@ class Game {
     this.renderer = new THREE.WebGLRenderer();
     this.renderer.setSize(window.innerWidth, window.innerHeight);
     this.renderer.shadowMap.enabled = true;
-    this.renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
 
     this.level = undefined;
 

--- a/static/scenes/railroad/js/scene.js
+++ b/static/scenes/railroad/js/scene.js
@@ -38,7 +38,10 @@ class Scene {
     for (const imageName of ELF_IMAGE_NAMES) {
       const imagePromise = textureLoader
         .loadAsync(`img/${imageName}`)
-        .then(texture => elfImages.set(imageName, texture))
+        .then(texture => {
+          texture.colorSpace = THREE.SRGBColorSpace;
+          elfImages.set(imageName, texture);
+        })
         .then(_ => console.log(`Loaded ${imageName}`))
       promises.push(imagePromise);
     }


### PR DESCRIPTION
GitHub doesn't support dependant Pull Requests very well but this one is dependent on https://github.com/google/santa-tracker-web/pull/152 and is just really the final commit.

This colors of everything else in the 3D scene was off which made we realize that we needed to adjust only the sprites, not everything.