### PR TITLE
Switch from 'click' event to 'pointerdown' event.

### DIFF
--- a/static/scenes/railroad/js/game.js
+++ b/static/scenes/railroad/js/game.js
@@ -121,7 +121,7 @@ class Game {
   }
 
   setUpListeners() {
-    this.renderer.domElement.addEventListener('click', (click) => {
+    this.renderer.domElement.addEventListener('pointerdown', (click) => {
       this.handleClick(click);
     });
 


### PR DESCRIPTION
This makes things snappier, especially on mobile and touch interfaces.