### PR TITLE
Use default focus styling for buttons

### DIFF
--- a/static/src/elements/santa-button.scss
+++ b/static/src/elements/santa-button.scss
@@ -88,11 +88,6 @@ button {
     transform: translate(0, 0);
   }
 
-  &:focus {
-    border-color: rgba(0, 0, 0, 0.33);
-    outline: none;
-  }
-
   @mixin theme($color) {
     background: $color;
     box-shadow: $offset-x $offset-y 0 rgba(0, 0, 0, 0.3),


### PR DESCRIPTION
The default styling in chrome has much better visibility. Will need to check how this looks with other devices but this is a step up from the current styling as far as accessibility goes.