### PR TITLE
Set aria-label on santa-button elements properly

### DIFF
--- a/static/src/elements/santa-button.js
+++ b/static/src/elements/santa-button.js
@@ -38,7 +38,7 @@ export class SantaButtonElement extends LitElement {
       path: {type: String},
       color: {type: String},
       disabled: {type: Boolean, reflect: true},
-      'aria-label': {type: String, reflect: true}
+      ariaLabel: {reflect: true, attribute: 'aria-label'}
     };
   }
 
@@ -81,7 +81,11 @@ export class SantaButtonElement extends LitElement {
     }
 
 
-    return html`<button class="${this.color || ''}" .disabled=${this.disabled} @click=${this._maybePreventClick} aria-label=${this['aria-label']}>${inner}</button>`;
+    return html`<button
+      class="${this.color || ''}"
+      .disabled=${this.disabled}
+      @click=${this._maybePreventClick}
+      aria-label=${this.ariaLabel || nothing}>${inner}</button>`;
   }
 
   focus() {
@@ -92,6 +96,11 @@ export class SantaButtonElement extends LitElement {
     if (this.disabled) {
       event.stopImmediatePropagation();
     }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.role = 'presentation';
   }
 }
 

--- a/static/src/elements/santa-button.js
+++ b/static/src/elements/santa-button.js
@@ -38,6 +38,7 @@ export class SantaButtonElement extends LitElement {
       path: {type: String},
       color: {type: String},
       disabled: {type: Boolean, reflect: true},
+      'aria-label': {type: String, reflect: true}
     };
   }
 
@@ -80,7 +81,7 @@ export class SantaButtonElement extends LitElement {
     }
 
 
-    return html`<button class="${this.color || ''}" .disabled=${this.disabled} @click=${this._maybePreventClick}>${inner}</button>`;
+    return html`<button class="${this.color || ''}" .disabled=${this.disabled} @click=${this._maybePreventClick} aria-label=${this['aria-label']}>${inner}</button>`;
   }
 
   focus() {


### PR DESCRIPTION
We have a lot of santa-button elements with aria labels, but the element creates a creates a child button, and that's what gets focused and actually needs the aria-label on it. This sets the aria label of the child button too.