### PR TITLE
Explicitly set focus for railroad game / homepage

### DIFF
--- a/static/entrypoint.js
+++ b/static/entrypoint.js
@@ -597,6 +597,13 @@ async function runner(control, route) {
       case 'tutorial-dismiss':
         tutorialOverlayElement.dismiss(...payload);
         continue;
+
+      case 'focus-on-menu':
+        // We dig into the shadow root of this component, which sort of breaks
+        // encapsulation. A 'nicer' approach might be to add some functionality
+        // into the santa-chrome element. But for the moment this works and is a
+        // quick fix for an accessibility issue.
+        document.querySelector('santa-chrome').shadowRoot.querySelector('.menu-button').focus();
     }
 
     console.debug('running scene unhandled', op);

--- a/static/scenes/modvil/index.html
+++ b/static/scenes/modvil/index.html
@@ -328,6 +328,9 @@ api.ready(async () => {
 
   // force focus
   trackerElement.focusOnSanta();
+
+  // Set the default page focus on the menu button.
+  api.focusOnMenu();
 });
 
 </script>

--- a/static/scenes/railroad/js/game.js
+++ b/static/scenes/railroad/js/game.js
@@ -88,6 +88,9 @@ class Game {
     this.startLevel();
     this.paused = false;
     this.scoreboard.restart()
+
+    // Focus on the main button for keyboard controls after restarting.
+    this.containerButton.focus();
   }
 
   gameover() {

--- a/static/src/elements/santa-chrome.js
+++ b/static/src/elements/santa-chrome.js
@@ -100,7 +100,7 @@ export class SantaChromeElement extends LitElement {
 </div>
 <div id="padder">
   <header>
-    <santa-button aria-label=${labelForMenu} @click=${this._onMenuClick} path=${this.showHome ? paths.home : paths.menu}></santa-button>
+    <santa-button class="menu-button" aria-label=${labelForMenu} @click=${this._onMenuClick} path=${this.showHome ? paths.home : paths.menu}></santa-button>
     <santa-button .hidden=${isAndroid()} aria-label=${labelForAudio} color=${this.muted ? 'purple' : ''} @click=${this._onAudioClick} path=${this.muted ? paths.unmute : paths.mute}></santa-button>
     <santa-button aria-label=${labelForAction} ?disabled=${!this.action} @click=${this._onActionClick} path=${paths[this.action || this._lastAction] || ''}></santa-button>
     <div class="grow"></div>

--- a/static/src/scene/api.js
+++ b/static/src/scene/api.js
@@ -155,6 +155,7 @@ const sceneApi = (function() {
   const bufferNames = {
     'tutorialQueue': true,
     'tutorialDismiss': true,
+    'focusOnMenu': true,
     'ga': true,
     'play': true,
     'data': false,


### PR DESCRIPTION
- When the game is restarted, set the keyboard focus on the main button
- When the main page of the game loads, set the focus on the menu button.

There are many more places where the focus handling needs work, however this is a start and specifically fixes the bugs filed for the game.