### PR TITLE
Fix scoreboard restart to also reset score

### DIFF
--- a/static/scenes/railroad/js/game.js
+++ b/static/scenes/railroad/js/game.js
@@ -94,7 +94,7 @@ class Game {
 
     this.startLevel();
     this.paused = false;
-    this.scoreboard.restart()
+    this.scoreboard.reset()
 
     // Focus on the main button for keyboard controls after restarting.
     this.containerButton.focus();


### PR DESCRIPTION
The reset call restarts the timer as well as the score.