### PR TITLE
Update compile-html.js DOM text reinterpreted as HTML

### DIFF
--- a/build/compile-html.js
+++ b/build/compile-html.js
@@ -50,7 +50,7 @@ module.exports = async (filename, options) => {
     } else if (node.closest('head') && node.localName !== 'title') {
       throw new Error(`unhandled <head> node: ${node.localName}`);
     } else {
-      node.innerHTML = string;
+      node.innerText = string;
     }
 
     node.removeAttribute('msgid');


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.
