### PR TITLE
Update magic.js DOM text reinterpreted as HTML

### DIFF
--- a/static/src/magic.js
+++ b/static/src/magic.js
@@ -68,7 +68,7 @@ export function _static(path) {
       return;
     }
 
-    el.innerHTML = _msg(el.getAttribute('msgid'));
+    el.innerText = _msg(el.getAttribute('msgid'));
   }
 
   Array.from(document.body.querySelectorAll('[msgid]')).map(upgrade);


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.

