### PR TITLE
Update cloud build go version to the latest version

### DIFF
--- a/.cloudbuild/staging/appengine/app.yaml
+++ b/.cloudbuild/staging/appengine/app.yaml
@@ -1,4 +1,4 @@
-runtime: go115
+runtime: go122
 
 handlers:
 - url: /.*


### PR DESCRIPTION
Cloud builds for staging are currently failing with

"ERROR: (gcloud.app.deploy) INVALID_ARGUMENT: Error(s) encountered validating runtime. Runtime go115 is end of support and no longer allowed. Please use the latest Go runtime for App Engine Standard. For internal google applications, please see go/gae-end-of-support."

Updating to the latest version of go should fix this.

https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#go