### PR TITLE
Update Google Analytics Tracking code to use GA4 properties and gtag library

### DIFF
--- a/prod/error.html
+++ b/prod/error.html
@@ -79,10 +79,11 @@
     </p>
   </div>
   <script>
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', 'UA-37048309-' + (location.hostname === 'santatracker.google.com' ? 1 : 2), 'auto');
-ga('send', 'pageview');
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', location.hostname === 'santatracker.google.com' ? 'G-NK3LZ78Q1G' : 'G-S9MKN6FWD0');
   </script>
-  <script async src="https://www.google-analytics.com/analytics.js"></script>
 </body>
 </html>

--- a/prod/error.html
+++ b/prod/error.html
@@ -78,6 +78,7 @@
       <a class="button" href="./?fallback=1&amp;ignore=1">Unsupported browsers</a>
     </p>
   </div>
+  <script async src="https://www.googletagmanager.com/gtag/js"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}

--- a/prod/index.html
+++ b/prod/index.html
@@ -54,12 +54,14 @@
   <link id="favicon" rel="shortcut icon" href="/images/favicon-96.png" sizes="96x96" />
 
   <!-- Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js"></script>
   <script>
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', 'UA-37048309-' + (location.hostname === 'santatracker.google.com' ? 1 : 2), 'auto');
-    ga('set', 'transport', 'beacon');
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', location.hostname === 'santatracker.google.com' ? 'G-NK3LZ78Q1G' : 'G-S9MKN6FWD0');
   </script>
-  <script async src="https://www.google-analytics.com/analytics.js"></script>
 
   <!-- CSS -->
   <style>

--- a/prod/src/firebase.js
+++ b/prod/src/firebase.js
@@ -65,7 +65,7 @@ export function initialize() {
   window.firebase = firebase;  // side-effect
 
   return remoteConfig.fetchAndActivate().catch((err) => {
-    ga('send', 'event', 'config', 'failure', 'firebase', {nonInteraction: true});
+    gtag('event', 'firebase', {action: 'failure'});
     console.warn('could not fetch remoteConfig, using defaults', err);
   }).then(() => {
     return remoteConfig;

--- a/prod/upgrade.html
+++ b/prod/upgrade.html
@@ -71,6 +71,7 @@
     <p msgid="upgrade-warning">Oops! Santa Tracker isn't supported in your browser or you have JavaScript disabled. To access Santa Tracker, download a modern browser or enable JavaScript.<br />For more information visit <a href="https://whatbrowser.org">whatbrowser.org</a></p>
     <p><a class="button" href="./?ignore_browser_check=true" msgid="gotovillage">Go to the Village</a></p>
   </div>
+  <script async src="https://www.googletagmanager.com/gtag/js"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}

--- a/prod/upgrade.html
+++ b/prod/upgrade.html
@@ -72,10 +72,11 @@
     <p><a class="button" href="./?ignore_browser_check=true" msgid="gotovillage">Go to the Village</a></p>
   </div>
   <script>
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', 'UA-37048309-' + (location.hostname === 'santatracker.google.com' ? 1 : 2), 'auto');
-ga('send', 'pageview');
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', location.hostname === 'santatracker.google.com' ? 'G-NK3LZ78Q1G' : 'G-S9MKN6FWD0');
   </script>
-  <script async src="https://www.google-analytics.com/analytics.js"></script>
 </body>
 </html>

--- a/static/entrypoint.js
+++ b/static/entrypoint.js
@@ -284,7 +284,7 @@ global.subscribe((state) => {
   // This happens first, as we modify state as a side-effect.
   if (state.status === 'restart') {
     state.status = '';  // nb. modifies state as side effect
-    ga('send', 'event', 'game', 'start', state.route);
+    gtag('event', 'gameAction', {game: state.route, action: 'start'});
     state.control.send({type: 'restart'});
   }
 
@@ -535,14 +535,15 @@ async function runner(control, route) {
   let recentScore = null;
 
   // nb. we also call this as a result of 'restart'
-  ga('send', 'event', 'game', 'start', route);
+  gtag('event', 'gameAction', {game: route, action: 'start'});
   const analyticsLogEnd = () => {
     if (!recentScore) {
       return;
     }
-    ga('send', 'event', 'game', 'end', route);
-    recentScore.score && ga('send', 'event', 'game', 'score', route, recentScore.score);
-    recentScore.level && ga('send', 'event', 'game', 'level', route, recentScore.level);
+    // These could probably all be a single event with level+score being optional fields.
+    gtag('event', 'gameAction', {game: route, action: 'end'});
+    recentScore.score && gtag('event', 'gameAction', {game: route, action: 'score', extra: recentScore.score});
+    recentScore.level && gtag('event', 'gameAction', {game: route, action: 'level', extra: recentScore.level});
     recentScore = null;
   };
 

--- a/static/scenes/_shared/js/externs.js
+++ b/static/scenes/_shared/js/externs.js
@@ -37,7 +37,7 @@ window.santaApp.fire = function(name, ...data) {}
  * @param {...?} var_args
  * @return {?}
  */
-function ga(methodName, var_args) {}
+function gtag(methodName, var_args) {}
 
 /**
  * @constructor

--- a/static/scenes/airport/js/controls.js
+++ b/static/scenes/airport/js/controls.js
@@ -45,7 +45,7 @@ app.Controls.prototype = {
    * @private
    */
   updateState_: function(direction) {
-    window.ga('send', 'event', 'game', 'interact', 'airport');
+    gtag('event', 'gameAction', {game: 'airport', action: 'interact'});
     if (direction > 0) {
       this.state.nextState();
     } else if (direction < 0) {

--- a/static/scenes/boatload/js/game.js
+++ b/static/scenes/boatload/js/game.js
@@ -334,7 +334,7 @@ Game.prototype.hitBoat = function(score, time, x, y) {
   this.animate_(this.scoreElem, x, y);
   this.scoreboard.addScore(score);
   this.scoreboard.addTime(time);
-  window.ga('send', 'event', 'game', 'hit', 'boatload');
+  gtag('event', 'gameAction', {game: 'boatload', action: 'hit'});
 };
 
 /**
@@ -348,7 +348,7 @@ Game.prototype.missedBoat = function(present, x, y) {
   this.lastMissedPresent = present;
   present.missed();
   window.santaApp.fire('sound-trigger', 'bl_hit_water');
-  window.ga('send', 'event', 'game', 'miss', 'boatload');
+  gtag('event', 'gameAction', {game: 'boatload', action: 'miss'});
 };
 
 /**

--- a/static/scenes/commandcentre/js/scene.js
+++ b/static/scenes/commandcentre/js/scene.js
@@ -84,7 +84,7 @@ app.Scene.prototype = {
       window.santaApp.fire('sound-trigger', 'command_map');
     }
 
-    window.ga('send', 'event', 'game', 'interact', 'commandcentre');
+    gtag('event', 'gameAction', {game: 'commandcentre', action: 'interact'});
   },
 
   /**

--- a/static/scenes/demoscene/elements/easteregg-tictactoe.js
+++ b/static/scenes/demoscene/elements/easteregg-tictactoe.js
@@ -136,7 +136,7 @@ export class EasterEggTicTacToeElement extends LitElement {
 
     if (!this.cellsAvailable_.length) {
       // Draw
-      window.ga('send', 'event', 'village', 'tic-tac', 'draw', {nonInteraction: true});
+      window.gtag('event', 'village', {action: 'none', label: 'tic-tac-draw'});
     }
 
     this.turn = !this.turn;
@@ -154,7 +154,7 @@ export class EasterEggTicTacToeElement extends LitElement {
   async showWin_(player, w) {
     this.isPlaying = false;
 
-    window.ga('send', 'event', 'village', 'tic-tac', player, {nonInteraction: true});
+    window.gtag('event', 'village', {action: 'none', label: 'tic-tac-win', player});
 
     await delay(SHOW_LINE_TIME);
     this.winClass = `${player} pos-${w}`;

--- a/static/scenes/elfmaker/index.js
+++ b/static/scenes/elfmaker/index.js
@@ -77,7 +77,7 @@ share.addEventListener('click', (ev) => {
 random.addEventListener('click', (ev) => {
   window.santaApp.fire('sound-trigger', 'elfmaker_switch_item');
   control.chooseRandom();
-  window.ga('send', 'event', 'game', 'random', 'elfmaker');
+  gtag('event', 'gameAction', {game: 'elfmaker', action: 'random'});
 });
 
 downloadButton.addEventListener('click', (ev) => {
@@ -91,7 +91,7 @@ camera.addEventListener('click', (ev) => {
     download.setAttribute('href', src);
     downloadButton.disabled = false;
   });
-  window.ga('send', 'event', 'game', 'photo', 'elfmaker');
+  gtag('event', 'gameAction', {game: 'elfmaker', action: 'photo'});
 });
 
 photo.addEventListener('hide', (ev) => {
@@ -100,7 +100,7 @@ photo.addEventListener('hide', (ev) => {
 });
 
 download.addEventListener('click', (ev) => {
-  window.ga('send', 'event', 'game', 'download', 'elfmaker');
+  gtag('event', 'gameAction', {game: 'elfmaker', action: 'download'});
   window.setTimeout(() => {
     // dismiss clears href, so delay it
     photo.dismiss();
@@ -207,7 +207,7 @@ api.ready(async (data) => {
   };
   applyRandomMove((Math.random() < 0.5 ? 'left' : 'right') + 'Wave');  // kicks off random timer
   elf.addEventListener('click', (ev) => {
-    window.ga('send', 'event', 'game', 'poke', 'elfmaker');
+    gtag('event', 'gameAction', {game: 'elfmaker', action: 'poke'});
     applyRandomMove();
   });
 

--- a/static/scenes/jamband/js/dragdrop.js
+++ b/static/scenes/jamband/js/dragdrop.js
@@ -93,7 +93,7 @@ app.Draggable.prototype.dragEnd_ = function(x, y) {
     this.el.appendTo(droppable);
     this.el.trigger('dropped', droppable.data());
 
-    window.ga('send', 'event', 'game', 'dropped', 'jamband');
+    gtag('event', 'gameAction', {game: 'jamband', action: 'dropped'});
   } else {
     this.el.appendTo(this.container);
     this.el.trigger('returned');

--- a/static/scenes/modvil/elements/maputils.js
+++ b/static/scenes/modvil/elements/maputils.js
@@ -71,7 +71,7 @@ export async function fetchRoute(url, year = (new Date().getFullYear())) {
       destinations = await destinations(fallbackUrl);
     } catch (e) {
       console.warn('failed to fetch fallback', fallbackUrl, e);
-      window.ga('send', 'event', 'tracker', 'destinations', 'failure');
+      window.gtag('event', 'tracker', {action: 'failure', label: 'destinations'});
     }
   }
 
@@ -122,7 +122,7 @@ export class DestinationsCache {
     this._listener = listener;
 
     if (this._destinations) {
-      window.ga('send', 'event', 'tracker', 'destinations', 'cache-hit');
+      window.gtag('event', 'tracker', {action: 'cache-hit', label: 'destinations'});
       this._listener(this._destinations);
     }
   }
@@ -146,7 +146,7 @@ export class DestinationsCache {
         localStorage['destinations'] = JSON.stringify(destinations);
         this._listener(destinations);
         this._task = null;
-        window.ga('send', 'event', 'tracker', 'destinations', 'fetch');
+        window.gtag('event', 'tracker', {action: 'fetch', label: 'destinations'});
       }
       return destinations;
     });
@@ -285,7 +285,7 @@ export class DataManager {
 
       if (this._destinations.length > 1) {
         // Log this, but only if we have real destination data (not just single Village stop).
-        window.ga('send', 'event', 'tracker', 'timezone-guess', cands[0].id);
+        window.gtag('event', 'tracker', {action: 'timezone-guess', label: 'destinations', value: cands[0].id});
         console.info('nearest stop (tz):', cands[0].id);
       }
 

--- a/static/scenes/modvil/elements/modvil-tracker.js
+++ b/static/scenes/modvil/elements/modvil-tracker.js
@@ -253,7 +253,7 @@ class ModvilTrackerElement extends LitElement {
   }
 
   _onMarkerClick(id) {
-    window.ga('send', 'event', 'tracker', 'click', 'marker');
+    gtag('event', 'tracker', {action: 'click', label: 'marker'});
     if (this.width <= 600) {
       return;  // ignore click, mobile UI
     }
@@ -330,7 +330,7 @@ class ModvilTrackerElement extends LitElement {
       if (!this._duringMapChange && !this._duringResize && this._focusOnSanta) {
         this._focusOnSanta = false;
         console.warn('removing focus', reason);
-        window.ga('send', 'event', 'tracker', 'map', reason);
+        gtag('event', 'tracker', {action: 'unfocusSanta', label: 'map', reason});
       }
     };
     this._map.addListener('center_changed', () => reset('move'));
@@ -386,7 +386,7 @@ class ModvilTrackerElement extends LitElement {
 
   _onFocusSantaClick() {
     this._focusOnSanta = true;
-    ga('send', 'event', 'tracker', 'click', 'focus-santa');
+    gtag('event', 'tracker', {action: 'click', label: 'focusSanta'});
   }
 }
 

--- a/static/scenes/modvil/index.html
+++ b/static/scenes/modvil/index.html
@@ -296,17 +296,17 @@ const configureActionButton = (button, callback) => {
 };
 
 configureActionButton(document.getElementById('play'), () => {
-  ga('send', 'event', 'village', 'click', 'play-round');
+  gtag('event', 'village', {action: 'click', label: 'play-round'});
   api.go(playRoute);
 });
 
 configureActionButton(document.getElementById('featuredButton'), () => {
-  ga('send', 'event', 'village', 'click', 'featured');
+  gtag('event', 'village', {action: 'click', label: 'featured'});
   api.go(featuredRoute);
 });
 
 configureActionButton(document.getElementById('familyguide'), () => {
-  ga('send', 'event', 'village', 'click', 'familyguide');
+  gtag('event', 'village', {action: 'click', label: 'familyguide'});
   api.go('familyguide');
 });
 

--- a/static/scenes/presentbounce/js/world/level.js
+++ b/static/scenes/presentbounce/js/world/level.js
@@ -116,7 +116,7 @@ app.world.Level = class {
    */
   onLevelCompleted() {
     if (this.attempt_ === 1) {
-      window.ga('send', 'event', 'game', 'firsttry', 'presentbounce')
+      gtag('event', 'gameAction', {game: 'presentbounce', action: 'firsttry'});
     }
 
     let score = 0;

--- a/static/scenes/presentbounce/js/world/spring.js
+++ b/static/scenes/presentbounce/js/world/spring.js
@@ -59,7 +59,7 @@ app.world.Spring = class extends app.world.UserObject {
     ) {
       app.shared.utils.animWithClass(this.$el_, 'animate');
       window.santaApp.fire('sound-trigger', 'pb_boing');
-      window.ga('send', 'event', 'game', 'bounce', 'presentbounce')
+      gtag('event', 'gameAction', {game: 'presentbounce', action: 'bounce'});
     }
   }
 

--- a/static/scenes/santascanvas/js/canvas.js
+++ b/static/scenes/santascanvas/js/canvas.js
@@ -404,7 +404,7 @@ app.Canvas.prototype.saveToFile = function(e) {
   saveCtx.drawImage(this.foregroundBackup, 0, 0, this.saveCanvas.width,
       this.saveCanvas.height);
 
-  window.ga('send', 'event', 'game', 'save', 'santascanvas');
+  gtag('event', 'gameAction', {game: 'santascanvas', action: 'save'});
 
   if (this.saveCanvas.msToBlob) { // for IE
     var blob = this.saveCanvas.msToBlob();
@@ -435,7 +435,7 @@ app.Canvas.prototype.saveToFile = function(e) {
 app.Canvas.prototype.onTrashClick = function(event) {
   this.snow.reset();
 
-  window.ga('send', 'event', 'game', 'trash', 'santascanvas');
+  gtag('event', 'gameAction', {game: 'santascanvas', action: 'trash'});
 
   this.clearAnimation.beginAnimation(this.resetCanvas.bind(this));
 

--- a/static/scenes/santasearch/js/character.js
+++ b/static/scenes/santasearch/js/character.js
@@ -156,7 +156,7 @@ app.Character.prototype.onFound_ = function() {
   if (this.isFound) {
     return;
   }
-  window.ga('send', 'event', 'game', 'found', 'santasearch')
+  gtag('event', 'gameAction', {game: 'santasearch', action: 'found'});
 
   window.santaApp.fire('sound-trigger', `ss_character_${this.name}`);
   let wasFocused = this.drawerItemElem.hasClass('drawer__item--focused');

--- a/static/scenes/santasearch/js/game.js
+++ b/static/scenes/santasearch/js/game.js
@@ -103,7 +103,7 @@ app.Game.prototype.getRandomHintDistanceOffset_ = function() {
  */
 app.Game.prototype.hintLocation_ = function(character) {
   window.santaApp.fire('sound-trigger', 'ss_button_hint');
-  window.ga('send', 'event', 'game', 'hint', 'santasearch')
+  gtag('event', 'gameAction', {game: 'santasearch', action: 'hint'});
 
   // The location of the character is a top/left percentage of the map
   let characterLocation = character.location;

--- a/static/scenes/snowball/js/snowball/levels/local-level.js
+++ b/static/scenes/snowball/js/snowball/levels/local-level.js
@@ -83,7 +83,7 @@ export class LocalLevel extends MainLevel {
       window.santaApp.fire('game-stop', {
         score: population.knockedOut,
       });
-      window.ga('send', 'event', 'game', 'win', 'snowball');
+      gtag('event', 'gameAction', {game: 'snowball', action: 'win'});
     }
   }
 }

--- a/static/scenes/speedsketch/js/views/cardsView.js
+++ b/static/scenes/speedsketch/js/views/cardsView.js
@@ -121,7 +121,7 @@ app.view.CardsView.prototype.showTimesUpCard = function(rounds, callback) {
       roundsRecognized));
   }
 
-  window.ga('send', 'event', 'game', 'recognized', 'speedsketch', roundsRecognized);
+  gtag('event', 'gameAction', {game: 'speedsketch', action: 'recognized', extra: roundsRecognized});
 
   var modelWidth = 300;
   var modelHeight = 225;

--- a/static/scenes/translations/js/scene.js
+++ b/static/scenes/translations/js/scene.js
@@ -132,7 +132,7 @@ app.Scene.prototype.setDefaultLanguages_ = function() {
  * @param {string} klangEvent to fire to Klang for Elvish
  */
 app.Scene.prototype.playAudio_ = function(string, lang, klangEvent) {
-  window.ga('send', 'event', 'game', 'listen', 'translations');
+  gtag('event', 'gameAction', {game: 'translations', action: 'listen'});
 
   if (this.toLang === 'elvish') {
     window.santaApp.fire('sound-trigger', klangEvent);

--- a/static/src/core/config.js
+++ b/static/src/core/config.js
@@ -61,11 +61,11 @@ function checkUpgrade() {
   // otherwise, reload or complain
   console.warn('got out-of-date version, have', siteVersion, 'want', upgradeToVersion);
   if (!isProd || localStorage['upgradeToVersion'] === upgradeToVersion) {
-    ga('send', 'event', 'site', 'upgrade-warn', upgradeToVersion);
+    gtag('event', 'site', {action: 'upgrade-warn', label: upgradeToVersion});
     isOutOfDate = true;
     notifyListeners();
   } else {
-    ga('send', 'event', 'site', 'upgrade-attempt', upgradeToVersion);
+    gtag('event', 'site', {action: 'upgrade-attempt', label: upgradeToVersion});
     localStorage['upgradeToVersion'] = upgradeToVersion;
     window.location.href = window.location.href;
   }

--- a/static/src/core/loader.js
+++ b/static/src/core/loader.js
@@ -67,8 +67,14 @@ export function buildLoader(loadMethod, fallback=false) {
 
     window.dispatchEvent(new CustomEvent('loader-route', {detail: route}));
 
-    ga('set', 'page', `/${route}`);
-    ga('send', 'pageview');
+    // We must manually track page views for this application because
+    // it is a single page application, and automatically tracking all
+    // url changes will capture query parameter changes that should
+    // not be tracked as page views.
+    gtag('event', 'page_view', {
+      page_title: sceneName,
+      page_location: `/${route}`
+    });
 
     const locked = (activeSceneName === null);
     loadMethod(url, {route, data, locked}).then((success) => {

--- a/static/src/elements/santa-chrome.js
+++ b/static/src/elements/santa-chrome.js
@@ -155,16 +155,16 @@ export class SantaChromeElement extends LitElement {
   }
 
   _onAudioClick() {
-    window.ga('send', 'event', 'nav', 'click', this.muted ? 'unmute' : 'mute');
+    window.gtag('event', 'nav', {action: this.muted ? 'unmute' : 'mute'});
     this.dispatchEvent(new CustomEvent('audio', {detail: this.muted}));
   }
 
   _onMenuClick() {
     if (this.showHome) {
-      window.ga('send', 'event', 'nav', 'click', 'home');
+      window.gtag('event', 'nav', {action: 'home'});
       window.dispatchEvent(new CustomEvent(common.goEvent));  // home
     } else {
-      window.ga('send', 'event', 'nav', 'click', 'menu');
+      window.gtag('event', 'nav', {action: 'menu'});
       this.navOpen = !this.navOpen;
     }
   }
@@ -181,7 +181,7 @@ export class SantaChromeElement extends LitElement {
 
 
   _onActionClick(e) {
-    window.ga('send', 'event', 'nav', 'click', this.action);
+    window.gtag('event', 'nav', {action: this.action});
     this.dispatchEvent(new CustomEvent('action', {
       detail: this.action,
       bubbles: true,

--- a/static/src/elements/santa-gameloader.js
+++ b/static/src/elements/santa-gameloader.js
@@ -315,7 +315,7 @@ class SantaGameLoaderElement extends HTMLElement {
 
     const port = await prepareMessage(frame, 30 * 1000);
     if (frame !== this._activeFrame) {
-      window.ga('send', 'event', 'nav', 'preempted', 'load');
+      window.gtag('event', 'nav', {action: 'preempted-load'});
       return null;  // check for preempt
     }
 
@@ -331,7 +331,7 @@ class SantaGameLoaderElement extends HTMLElement {
         ready: () => {
           resolve(port ? control : null);  // resolve with null if there's no scene here
           if (frame !== this._activeFrame) {
-            window.ga('send', 'event', 'nav', 'preempted', 'port');
+            window.gtag('event', 'nav', {action: 'preempted-port'});
             return false;  // no longer active
           }
           this.purge();

--- a/static/src/elements/santa-install.js
+++ b/static/src/elements/santa-install.js
@@ -33,7 +33,9 @@ window.addEventListener('beforeinstallprompt', (event) => {
   event.preventDefault();
   installEvent = event;
   notifyInstances();
-  window.ga('send', 'event', 'app', 'beforeinstallprompt');
+  window.gtag('event', 'app', {
+    action: 'beforeinstallprompt',
+  });
   console.info('beforeinstallprompt');
 });
 
@@ -41,7 +43,9 @@ window.addEventListener('beforeinstallprompt', (event) => {
 window.addEventListener('appinstalled', () => {
   installEvent = null;
   notifyInstances();
-  window.ga('send', 'event', 'app', 'appinstalled');
+  window.gtag('event', 'app', {
+    action: 'appinstalled',
+  });
   console.info('appinstalled');
 });
 
@@ -77,14 +81,18 @@ class SantaInstallElement extends LitElement {
 
     if (!installEvent) {
       if (isIos) {
-        window.ga('send', 'event', 'nav', 'click', 'install-ios');
+        window.gtag('event', 'nav', {
+          action: 'install-ios',
+        });
       }
       event.target.focus();  // Safari doesn't focus <button> by default
       return;  // this can happen on iOS, when clicking does nothing
     }
 
     installEvent.prompt();
-    window.ga('send', 'event', 'nav', 'click', 'install');
+    window.gtag('event', 'nav', {
+      action: 'install',
+    });
 
     const savedEvent = installEvent;
     Promise.resolve(installEvent.userChoice || 'unknown').then((choiceResult) => {
@@ -93,7 +101,10 @@ class SantaInstallElement extends LitElement {
         installEvent = null;
         notifyInstances();
       }
-      window.ga('send', 'event', 'app', 'install', choiceResult);
+      window.gtag('event', 'app', {
+        action: 'install',
+        data: choiceResult,
+      });
     });
   }
 

--- a/static/src/elements/santa-overlay.js
+++ b/static/src/elements/santa-overlay.js
@@ -89,7 +89,7 @@ export class SantaOverlayElement extends LitElement {
     input.select();
     document.execCommand('copy');
     input.setSelectionRange(0, 0);
-    window.ga('send', 'event', 'nav', 'click', 'copy-url');
+    window.gtag('event', 'nav', {action: 'copy-url'});
 
     input.classList.add('copy');
     window.requestAnimationFrame(() => {
@@ -142,7 +142,7 @@ export class SantaOverlayElement extends LitElement {
 
   _onBelowClick(event) {
     if (event.target && event.target.localName === 'santa-card') {
-      window.ga('send', 'event', 'nav', 'click', 'below-card');
+      window.gtag('event', 'nav', {action: 'below-card'});
     }
   }
 }

--- a/static/src/kplay.js
+++ b/static/src/kplay.js
@@ -1235,7 +1235,7 @@ export function prepare() {
 
       if (typeof event === 'string') {
         console.debug('audio missing', event);
-        ga('send', 'event', 'site', 'audio-failure', event)
+        gtag('event', 'site', {action: 'audio-failure', label: event});
         return false;
       }
       console.warn('got invalid arg for kplay lookup', event);

--- a/static/src/scene/api.js
+++ b/static/src/scene/api.js
@@ -156,7 +156,7 @@ const sceneApi = (function() {
     'tutorialQueue': true,
     'tutorialDismiss': true,
     'focusOnMenu': true,
-    'ga': true,
+    'gtag': true,
     'play': true,
     'data': false,
     'score': false,
@@ -172,7 +172,7 @@ const sceneApi = (function() {
   }
 
   // Add global Analytics passthrough.
-  window.ga = target.ga;
+  window.gtag = target.gtag;
 
   // Handle common sound playback code. This is buffered just like `api.play()`.
   window.addEventListener(common.playEvent, (ev) => target.play(...ev.detail));


### PR DESCRIPTION
I did a quick pass at converting all of our events for the UA properties to custom events for the GA4 properties.

There is definitely room for improvement, but we can wait to fix these until later if we prefer to merge this as is.

Here is an example of some of the real time data we can see coming into the staging GA4 property:
![Screenshot 2024-05-23 at 10 26 43 AM](https://github.com/google/santa-tracker-web/assets/1253252/d49a5701-fcc5-4f7f-b28e-a097e4195f11)

My understanding is that it is possible to see nice charts for our custom GA4 events, but we have to configure views in GA for each of them to do this.
