### PR TITLE
Allow adjust Santa's location using a query parameter.

### DIFF
--- a/static/entrypoint.js
+++ b/static/entrypoint.js
@@ -775,4 +775,16 @@ configureCustomKeys(loaderElement);
     global.setState({trackerOffset});
   };
 
+  // Outside of production, allow adjusting Santa's location using a query parameter.
+  if (window.location.hostname !== 'santatracker.google.com') {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const testLocation = params.get('adjustSanta');
+      if (testLocation >= 0 && testLocation <= 1) {
+        window.santaApp.adjustSanta(testLocation);
+      }
+    } catch (e) {
+      // ignore
+    }
+  }
 }());


### PR DESCRIPTION
Allow adjusting Santa's location outside of production by setting the `adjustSanta` query parameter in the url, for example: `?adjustSanta=0.5`