### PR TITLE
Fix adjustSanta parameter was applying even when it was not set in the url.

### DIFF
--- a/static/entrypoint.js
+++ b/static/entrypoint.js
@@ -779,7 +779,7 @@ configureCustomKeys(loaderElement);
   if (window.location.hostname !== 'santatracker.google.com') {
     try {
       const params = new URLSearchParams(window.location.search);
-      const testLocation = params.get('adjustSanta');
+      const testLocation = Number.parseFloat(params.get('adjustSanta'));
       if (testLocation >= 0 && testLocation <= 1) {
         window.santaApp.adjustSanta(testLocation);
       }


### PR DESCRIPTION
It appears `params.get('foo')` returns null when there is no parameter and `null >= 0 && null <= 1` is `true`.

Worth noting:
These are both true: `null <=0` `null >= 0`
These are both false: `null < 0` `null > 0`
But this is also false: `null == 0`

So null appears to be 0 for greater/less than comparisons, but not actually loosely equal to 0 in js.

I'm a bit surprised I hadn't noticed this before now.