### PR TITLE
Support new testing query parameters outside of production.

### DIFF
--- a/static/entrypoint.js
+++ b/static/entrypoint.js
@@ -182,7 +182,8 @@ chromeElement.addEventListener('sidebar-open', (ev) => {
 
     let playNextRoute = cards[0];
 
-    let featured = firebaseConfig.featuredRoute();
+    // The debug value on the global state takes precedence over the value from firebase.
+    let featured = global.getState().featured || firebaseConfig.featuredRoute();
     if (featured === 'takeoff' || featured === 'liftoff') {
       // FIXME: hack for HPP
       featured = 'likealight';
@@ -454,12 +455,14 @@ async function prepare(control, data) {
             global.unsubscribe(listener);
             return;
           }
-          const {playNextRoute, trackerOffset} = global.getState();
+          const {featured, playNextRoute, showTracker, trackerOffset} = global.getState();
           const payload = {
             android: isAndroid(),
             routes: firebaseConfig.routesSnapshot(),
-            featured: firebaseConfig.featuredRoute(),
+            // The debug value on the global state takes precedence over the value from firebase.
+            featured: featured || firebaseConfig.featuredRoute(),
             play: playNextRoute,
+            showTracker,
             trackerFlags: firebaseConfig.trackerFlags(),
             trackerOffset,
             loudCard: firebaseConfig.loudCard(),
@@ -775,13 +778,36 @@ configureCustomKeys(loaderElement);
     global.setState({trackerOffset});
   };
 
-  // Outside of production, allow adjusting Santa's location using a query parameter.
+  // Outside of production we support several query parameters for testing the tracker.
   if (window.location.hostname !== 'santatracker.google.com') {
     try {
       const params = new URLSearchParams(window.location.search);
+      // Adjusting Santa's location using the 'adjustSanta' query parameter.
       const testLocation = Number.parseFloat(params.get('adjustSanta'));
       if (testLocation >= 0 && testLocation <= 1) {
         window.santaApp.adjustSanta(testLocation);
+      }
+      // Start with the tracker closed and open it in N seconds using the 'testOpenTracker' parameter.
+      const secondsToOpenTracker = Number.parseFloat(params.get('testOpenTracker'));
+      if (secondsToOpenTracker > 0) {
+        global.setState({showTracker: false});
+        setTimeout(() => {
+          global.setState({showTracker: true});
+        }, 1000 * secondsToOpenTracker);
+      }
+      // Start with the tracker open and close it in N seconds using the 'testCloseTracker' parameter.
+      const secondsToCloseTracker = Number.parseFloat(params.get('testCloseTracker'));
+      if (secondsToCloseTracker > 0) {
+        global.setState({showTracker: true});
+        setTimeout(() => {
+          global.setState({showTracker: false});
+        }, 1000 * secondsToCloseTracker);
+      }
+      // Set the featured game using the 'featuredGame' parameter.
+      const featuredGame = params.get('featuredGame');
+      if (featuredGame) {
+        global.setState({featured: featuredGame});
+        updatePlayNextCards();
       }
     } catch (e) {
       // ignore

--- a/static/global.js
+++ b/static/global.js
@@ -42,6 +42,10 @@ const g = createStore({
   shareUrl: null,
 
   trackerOffset: 0,
+
+  // These values are only used for debugging purposes and should not be set in production.
+  featured: undefined, // Test the "featured game" functionality on the homepage.
+  showTracker: undefined, // For the tracker to show or hide.
 });
 
 export default g;

--- a/static/global.js
+++ b/static/global.js
@@ -45,7 +45,7 @@ const g = createStore({
 
   // These values are only used for debugging purposes and should not be set in production.
   featured: undefined, // Test the "featured game" functionality on the homepage.
-  showTracker: undefined, // For the tracker to show or hide.
+  showTracker: undefined, // This forces the tracker to show or hide when set to true/false.
 });
 
 export default g;

--- a/static/scenes/modvil/index.html
+++ b/static/scenes/modvil/index.html
@@ -92,9 +92,11 @@ const fallbackFeaturedImageSrc = featuredImage.src;
 
 api.addEventListener('data', (ev) => {
   const payload = ev.detail;
-  const {trackerFlags, trackerOffset} = payload;
+  const {showTracker, trackerFlags, trackerOffset} = payload;
 
-  if (trackerFlags.showTracker) {
+  // The 'showTracker' value from the state overrides the trackerFlags and
+  // is only used for debugging outside of production.
+  if (showTracker || (showTracker !== false && trackerFlags.showTracker)) {
     if (trackerElement.parentNode !== mainElement) {
       mainElement.prepend(trackerElement);
       api.preload.wait(trackerElement.updateComplete);


### PR DESCRIPTION
Added the following test parameters for use outside of production:
* testOpenTracker=N, start with the tracker closed and open it after N seconds.
* testCloseTracker=N, start with the tracker open and close it after N seconds.
* featuredGame=gameId, show $gameId as the featured game, which effects the behavior of the "Play" button and adds a featured game card to the bottom right of the village section of the homepage.

I had to add an additional call to `updatePlayNextCards` in order to apply the featured game after reading it from the query parameters. It appears to be called earlier in a state where the query parameters are not available for some reason, perhaps something to do with how the application handles routing internally.