### PR TITLE
Build URL once when scoping URLs

### DIFF
--- a/static/src/scene/route.js
+++ b/static/src/scene/route.js
@@ -72,7 +72,7 @@ export const href = (cand) => {
     // ignore
   }
   // Make sure the protocol is http/https to avoid XSS.
-  return ["http:", "https:"].includes(url.protocol) ? url : null;
+  return ["http:", "https:"].includes(url?.protocol) ? url : null;
 };
 
 /**

--- a/static/src/scene/route.js
+++ b/static/src/scene/route.js
@@ -65,14 +65,14 @@ export const href = (cand) => {
   if (cand === null) {
     return null;
   }
-  let protocol = null;
+  let url = null;
   try {
-    protocol = (new URL(cand, page)).protocol;
+    url = new URL(cand, page);
   } catch(e) {
     // ignore
   }
   // Make sure the protocol is http/https to avoid XSS.
-  return ["http:", "https:"].includes(protocol) ? new URL(cand, page) : null;
+  return ["http:", "https:"].includes(url.protocol) ? url : null;
 };
 
 /**


### PR DESCRIPTION
I didn't see the comments in the previous PR and merged it. This PR contains a small fix to only build the URL once when scoping candidate URLs.