### PR TITLE
Fix build after most recent changes

### DIFF
--- a/release.js
+++ b/release.js
@@ -163,7 +163,9 @@ async function optionalMinify(code) {
     w.unref();
     w.terminate();
     if (result.error) {
-      throw new TypeError(`Terser error on ${fileName}: ${result.error}`);
+      throw new TypeError(
+        `Terser error[${result.error.filename}, l: ${result.error.line}]: ${result.error.message}`
+      );
     }
     code = result.code;
   });

--- a/static/src/scene/route.js
+++ b/static/src/scene/route.js
@@ -72,7 +72,7 @@ export const href = (cand) => {
     // ignore
   }
   // Make sure the protocol is http/https to avoid XSS.
-  return ["http:", "https:"].includes(url?.protocol) ? url : null;
+  return url && ["http:", "https:"].includes(url.protocol) ? url : null;
 };
 
 /**


### PR DESCRIPTION
Turns out we cannot use the operator ?. because it messes up with the minifier.

I was getting the following crash in the minifier:
`[19:41:36] Rewritten bundle static/fallback.js [entrypoint,i18n,transpile]...
[19:41:36] Rewritten bundle prod/loader.js [entrypoint,transpile]...
[19:41:36] Waiting on 1245 worker tasks...
ReferenceError: fileName is not defined
    at /usr/local/google/home/dandov/elfbuilder/santa-tracker-web/release.js:166:46
    at async WorkGroup.work (/usr/local/google/home/dandov/elfbuilder/santa-tracker-web/build/group.js:36:14)
    at async optionalMinify (/usr/local/google/home/dandov/elfbuilder/santa-tracker-web/release.js:154:3)
    at async /usr/local/google/home/dandov/elfbuilder/santa-tracker-web/release.js:539:14
    at async Promise.all (index 549)
    at async release (/usr/local/google/home/dandov/elfbuilder/santa-tracker-web/release.js:554:3)`

Turns out there was another bug in this thrown exception because the variable fileName doesn't exist. I fixed that by debugging the code and inspecting the contents of the error object. I started the debugger by running release.js with inspect:
`node inspect --experimental-worker --max-old-space-size=100000 ./release.js` 

From here I uncovered the real error:
`ebug> watchers
  0: result = { error: Object }
  1: result.error =
    { message: 'Unexpected token: punc (.)',
      filename: '0',
      line: 286,
      col: 42,
      pos: 7272 }`

Then just as a guess I figured that our most recent change included a ?. operator that seemed suspicious given that our release infra is pretty old and this is a new-ish operator.