### PR TITLE
feat(a11y): Improve accessibility of scroll and retro buttons

### DIFF
--- a/static/scenes/modvil/elements/modvil-arrow.js
+++ b/static/scenes/modvil/elements/modvil-arrow.js
@@ -36,7 +36,7 @@ class ModvilArrowElement extends LitElement {
   render() {
     return html`
 <div class="row">
-  <button id=${this._uniqueId} class="arrow ${this.dir}" @click=${this._onClick}></button>
+  <button aria-label="Scroll ${this.dir} to ${this.target}" id=${this._uniqueId} class="arrow ${this.dir}" @click=${this._onClick}></button>
   <label for=${this._uniqueId}><slot></slot></label>
 </div>
 `;

--- a/static/scenes/modvil/elements/modvil-village.js
+++ b/static/scenes/modvil/elements/modvil-village.js
@@ -78,7 +78,7 @@ class ModvilVillageElement extends LitElement {
       <div class="elfboard2"></div>
     </div>
     <div class="layer4">
-      <button class="retro" @click=${this._onClickRetro}></button>
+      <button aria-label="View Santa in Retro scene" class="retro" @click=${this._onClickRetro}></button>
       <div class="peekaboo" @animationiteration=${() => this._play('village_top_surprise')}>
         <div class="peekaboo-elf"></div>
         <div class="peekaboo-tree"></div>


### PR DESCRIPTION
This PR improves the accessibility of the Santa Tracker village (modvil) by adding descriptive aria-label attributes to key interactive elements, ensuring a better experience for screen reader users.

### Changes
* Retro Button: An aria-label has been added to the "retro" button to clearly state its function: "View Santa in Retro scene".
* Scroll Arrow Button: The scroll arrow button's aria-label is now dynamically generated to include both the direction and the target of the scroll (e.g., "Scroll down to village"), providing more context to the user.

### Impacted UI components
* Scroll up to top button
* Scroll down to village button
* Retro Santa button