### PR TITLE
feat(a11y): Enhance keyboard focus indicator for Santa cards

### DIFF
--- a/static/src/elements/santa-card.scss
+++ b/static/src/elements/santa-card.scss
@@ -39,6 +39,11 @@ a {
   &:focus {
     outline: none;
 
+    &:focus-visible {
+    box-shadow: 0 0 12px 4px white;
+    border-radius: var(--radius, 16px);
+    }
+
     main {
       &::before {
         opacity: 1;

--- a/static/src/elements/santa-card.scss
+++ b/static/src/elements/santa-card.scss
@@ -40,8 +40,8 @@ a {
     outline: none;
 
     &:focus-visible {
-    box-shadow: 0 0 12px 4px white;
-    border-radius: var(--radius, 16px);
+      box-shadow: 0 0 12px 4px white;
+      border-radius: var(--radius, 16px);
     }
 
     main {


### PR DESCRIPTION
This PR improves the accessibility of the Santa Tracker village by adding a clear and visually distinct keyboard focus indicator to interactive elements, ensuring a better experience for keyboard-dependent users. This addresses a violation related to GAR Web Keyboard Navigation.

### Changes
* **Santa Card Focus Indicator**: A white, rounded glow has been added to the `santa-card` elements. This is implemented using `box-shadow: 0 0 12px 4px white;` and `border-radius: var(--radius, 16px);` on the `:focus-visible` pseudo-class within `static/src/elements/santa-card.scss`. This ensures the focus indicator is only visible during keyboard navigation.

### Impacted UI components
* Santa Card links/buttons (interactive game cards in the menu)