### PR TITLE
feat(a11y): enhance keyboard focus indicator for arrow buttons

### DIFF
--- a/static/scenes/modvil/elements/modvil-arrow.scss
+++ b/static/scenes/modvil/elements/modvil-arrow.scss
@@ -76,6 +76,15 @@ button.arrow {
   &:focus {
     outline: 0;
 
+    &:focus-visible {
+      box-shadow: inset 0 0 2px 2px #eff1f4,
+        0 0 0 12px rgba(0, 0, 0, 0.24);
+
+      &::after {
+        background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTkiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxOSAxMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTIuODMwMjcgLTcuMDY4MDFlLTA3TDkuODM4NjggNi45OTAwOEwxNi44NDcxIC05LjQxMDY2ZS0wOEwxOSAyLjE1MjkyTDkuODM4NjggMTEuMzE0MkwwLjY3NzM2IDIuMTUyOTFMMi44MzAyNyAtNy4wNjgwMWUtMDdaIiBmaWxsPSIjNTBBNEZGIi8+Cjwvc3ZnPg==")
+      }
+    }
+
     &::before {
       opacity: 1;
     }


### PR DESCRIPTION
This PR improves the accessibility of the Santa Tracker village by adding a clear and visually distinct keyboard focus indicator to the arrow navigation buttons, ensuring a better experience for keyboard-dependent users.

### Changes
* **Stronger box shadow**: A strong, high-contrast shadow has been added to the `modvil-arrow` element. This is implemented using `box-shadow: inset 0 0 2px 2px #eff1f4, 0 0 0 12px rgba(0, 0, 0, 0.24);` on the `:focus-visible` pseudo-class within `static/scenes/modvil/elements/modvil-arrow.scss`. 
* **Icon color change**: The arrow icon color changes to a darker blue (`#50A4FF`) from `#9FCEFF` on focus to further enhance visibility. This ensures the high-contrast indicator is only visible during keyboard navigation.

### Impacted UI components
* Scroll up to top button.
* Scroll down to village button.
