### PR TITLE
feat(a11y): enhance keyboard focus order in View All menu page

### DIFF
--- a/static/src/elements/santa-cardnav.js
+++ b/static/src/elements/santa-cardnav.js
@@ -86,9 +86,8 @@ export class SantaCardNavElement extends LitElement {
     const available = [];
     const videos = config.videos();
 
-    const cardHtml = this.cards.map((sceneName, i) => {
-      const locked = config.lockedTo(sceneName);
-
+    // Calculate order for all cards
+    const cardsWithOrder = this.cards.map((sceneName) => {
       const isVideo = videos.indexOf(sceneName) !== -1;
 
       let order = currentOrder;
@@ -112,6 +111,15 @@ export class SantaCardNavElement extends LitElement {
         }
       }
 
+      return {sceneName, order, isVideo};
+    });
+
+    // Sort by visual order (for tab focus order)
+    cardsWithOrder.sort((a, b) => a.order - b.order);
+
+    // Render
+    const cardHtml = cardsWithOrder.map(({sceneName, order, isVideo}) => {
+      const locked = config.lockedTo(sceneName);
       const style = `transition-delay: ${0.2 + order * 0.05}s; order: ${order}`;
       return html`<santa-card style=${style} locked=${ifDefined(locked)} scene=${sceneName} .video=${isVideo} ?wide=${isVideo}></santa-card>`;
     });


### PR DESCRIPTION
This PR fixes an accessibility issue in the "View All" menu where the keyboard focus order was unpredictable, causing the tab focus to zig-zag between rows instead of following a logical flow.

### Changes
* **Synchronized DOM and Visual Order**: Refactored the `render` method in `santa-cardnav.js` to pre-calculate the layout position of each card based on the existing bin-packing logic.
* **Sorted Rendering**: The cards are now sorted by their calculated visual order before being rendered. This ensures that the DOM order matches the visual layout, guaranteeing a natural left-to-right, top-to-bottom tab sequence for keyboard users.
* **Preserved Layout Logic**: Maintained the existing algorithm that optimally places "wide" video cards and backs-fills gaps with standard cards, but now the accessibility tree reflects this structure.

### Impacted UI components
* Card Navigation (`santa-cardnav`): The component responsible for rendering the "View All" grid menu.
