### PR TITLE
fix(a11y): enhance label on track santa button

### DIFF
--- a/static/scenes/modvil/elements/modvil-tracker.js
+++ b/static/scenes/modvil/elements/modvil-tracker.js
@@ -48,7 +48,7 @@ const routeJitterRatio = +localStorage['routeJitter'] || 0;
 
 
 class ModvilTrackerElement extends LitElement {
-  static get styles() { return [styles]; }
+  static get styles() {return [styles];}
 
   static get properties() {
     return {
@@ -370,7 +370,7 @@ class ModvilTrackerElement extends LitElement {
     </div>
   </div>
   <div class="buttons">
-    <santa-button color="green" class=${this._focusOnSanta ? 'gone' : ''} @click=${this._onFocusSantaClick}>
+    <santa-button aria-label=${_msg`tracker_track`} color="green" class=${this._focusOnSanta ? 'gone' : ''} @click=${this._onFocusSantaClick}>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 257.22 139.5"><defs><style>.cls-1,.cls-3{fill:#fff;}.cls-1,.cls-4{stroke:#f9f9f9;stroke-miterlimit:10;}.cls-2{fill:#e53935;}.cls-4{fill:none;}</style></defs><title>hat_santa</title><g id="Layer_2" data-name="Layer 2"><g id="ART"><path class="cls-1" d="M55.9,28.21A27.7,27.7,0,1,1,28.21.5,27.69,27.69,0,0,1,55.9,28.21Z"/><path class="cls-2" d="M68.45,28.2l-1,0V139H242.87C242.87,77.8,164.78,28.2,68.45,28.2Z"/><rect class="cls-3" x="44.36" y="83.6" width="212.36" height="55.4" rx="16.37" ry="16.37"/><rect class="cls-4" x="44.36" y="83.6" width="212.36" height="55.4" rx="16.37" ry="16.37"/></g></g></svg>
     </santa-button>
   </div>

--- a/static/src/elements/santa-button.js
+++ b/static/src/elements/santa-button.js
@@ -15,7 +15,6 @@
  */
 
 import {html, LitElement} from 'lit-element';
-import {nothing} from 'lit-html';
 import {ifDefined} from 'lit-html/directives/if-defined';
 import * as common from '../../src/core/common.js';
 import styles from './santa-button.css';
@@ -88,8 +87,8 @@ export class SantaButtonElement extends LitElement {
       class="${this.color || ''}"
       .disabled=${this.disabled}
       @click=${this._maybePreventClick}
-      aria-expanded=${ifDefined(this.ariaExpanded || undefined)}
-      aria-label=${this.ariaLabel || nothing}>${inner}</button>`;
+      aria-expanded=${ifDefined(this.ariaExpanded)}
+      aria-label=${ifDefined(this.ariaLabel)}>${inner}</button>`;
   }
 
   focus() {


### PR DESCRIPTION
This PR fixes an accessibility issue where the "Track Santa" button (the Santa hat icon) on the tracker map was announced as "object object" by screen readers. This was due to a missing `aria-label` on the button instance and an issue with how the `santa-button` component handled undefined attributes.

### Changes
* **Accessible Label**: Added an `aria-label` to the Santa hat button in `modvil-tracker.js` using the localized string `tracker_track` (e.g., "Track Santa"). This ensures screen readers clearly announce the button's purpose and action.
* **Component Attribute Handling**: Refactored `SantaButtonElement` in `santa-button.js` to properly use `ifDefined` for `aria-label` and `aria-expanded`. This prevents `nothing` or `undefined` values from being rendered as stringified objects (like "object object") in the DOM.

### Impacted UI components
* Santa Tracker Map (`modvil-tracker`)
* Santa Button (`santa-button`)
