### PR TITLE
feat(a11y): announce dynamic location in Santa tracker button

### DIFF
--- a/_messages/en-GB.json
+++ b/_messages/en-GB.json
@@ -3560,6 +3560,12 @@
 	"tracker_next_stop": {
 		"message": "Next stop"
 	},
+	"tracker_santa_is_at": {
+		"message": "Santa Claus is at {{location}}"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "Santa Claus is heading to {{location}}"
+	},
 	"tracker_santa_update": {
 		"message": "SANTA UPDATE"
 	},

--- a/_messages/en.json
+++ b/_messages/en.json
@@ -3560,6 +3560,12 @@
 	"tracker_next_stop": {
 		"message": "Next stop"
 	},
+	"tracker_santa_is_at": {
+		"message": "Santa Claus is at {{location}}"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "Santa Claus is heading to {{location}}"
+	},
 	"tracker_santa_update": {
 		"message": "SANTA UPDATE"
 	},

--- a/_messages/ja.json
+++ b/_messages/ja.json
@@ -3560,6 +3560,12 @@
 	"tracker_next_stop": {
 		"message": "次の目的地"
 	},
+	"tracker_santa_is_at": {
+		"message": "サンタさんは現在 {{location}} にいます"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "サンタさんは {{location}} に向かっています"
+	},
 	"tracker_santa_update": {
 		"message": "サンタさんの最新情報"
 	},

--- a/_messages/ko.json
+++ b/_messages/ko.json
@@ -3560,6 +3560,12 @@
 	"tracker_next_stop": {
 		"message": "다음 방문지"
 	},
+	"tracker_santa_is_at": {
+		"message": "산타클로스는 현재 {{location}}에 있습니다"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "산타클로스는 {{location}}(으)로 향하고 있습니다"
+	},
 	"tracker_santa_update": {
 		"message": "산타 업데이트"
 	},

--- a/_messages/zh-CN.json
+++ b/_messages/zh-CN.json
@@ -3596,6 +3596,12 @@
 	"tracker_your_location": {
 		"message": "您所在的位置"
 	},
+	"tracker_santa_is_at": {
+		"message": "圣诞老人目前在 {{location}}"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "圣诞老人正前往 {{location}}"
+	},
 	"traditions-next": {
 		"message": "下一个习俗"
 	},

--- a/_messages/zh-CN.json
+++ b/_messages/zh-CN.json
@@ -3560,6 +3560,12 @@
 	"tracker_next_stop": {
 		"message": "下一站"
 	},
+	"tracker_santa_is_at": {
+		"message": "圣诞老人目前在 {{location}}"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "圣诞老人正前往 {{location}}"
+	},
 	"tracker_santa_update": {
 		"message": "圣诞老人最新行踪"
 	},
@@ -3595,12 +3601,6 @@
 	},
 	"tracker_your_location": {
 		"message": "您所在的位置"
-	},
-	"tracker_santa_is_at": {
-		"message": "圣诞老人目前在 {{location}}"
-	},
-	"tracker_santa_is_heading_to": {
-		"message": "圣诞老人正前往 {{location}}"
 	},
 	"traditions-next": {
 		"message": "下一个习俗"

--- a/_messages/zh-HK.json
+++ b/_messages/zh-HK.json
@@ -3560,6 +3560,12 @@
 	"tracker_next_stop": {
 		"message": "下一站"
 	},
+	"tracker_santa_is_at": {
+		"message": "聖誕老人目前在 {{location}}"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "聖誕老人正前往 {{location}}"
+	},
 	"tracker_santa_update": {
 		"message": "聖誕老人最新消息"
 	},
@@ -3595,12 +3601,6 @@
 	},
 	"tracker_your_location": {
 		"message": "您的地點"
-	},
-	"tracker_santa_is_at": {
-		"message": "聖誕老人目前在 {{location}}"
-	},
-	"tracker_santa_is_heading_to": {
-		"message": "聖誕老人正前往 {{location}}"
 	},
 	"traditions-next": {
 		"message": "下一個傳統"

--- a/_messages/zh-HK.json
+++ b/_messages/zh-HK.json
@@ -3596,6 +3596,12 @@
 	"tracker_your_location": {
 		"message": "您的地點"
 	},
+	"tracker_santa_is_at": {
+		"message": "聖誕老人目前在 {{location}}"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "聖誕老人正前往 {{location}}"
+	},
 	"traditions-next": {
 		"message": "下一個傳統"
 	},

--- a/_messages/zh-TW.json
+++ b/_messages/zh-TW.json
@@ -3560,6 +3560,12 @@
 	"tracker_next_stop": {
 		"message": "下一站"
 	},
+	"tracker_santa_is_at": {
+		"message": "聖誕老人目前在 {{location}}"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "聖誕老人正前往 {{location}}"
+	},
 	"tracker_santa_update": {
 		"message": "聖誕老人的最新狀態"
 	},
@@ -3595,12 +3601,6 @@
 	},
 	"tracker_your_location": {
 		"message": "你的位置"
-	},
-	"tracker_santa_is_at": {
-		"message": "聖誕老人目前在 {{location}}"
-	},
-	"tracker_santa_is_heading_to": {
-		"message": "聖誕老人正前往 {{location}}"
 	},
 	"traditions-next": {
 		"message": "下個傳統"

--- a/_messages/zh-TW.json
+++ b/_messages/zh-TW.json
@@ -3596,6 +3596,12 @@
 	"tracker_your_location": {
 		"message": "你的位置"
 	},
+	"tracker_santa_is_at": {
+		"message": "聖誕老人目前在 {{location}}"
+	},
+	"tracker_santa_is_heading_to": {
+		"message": "聖誕老人正前往 {{location}}"
+	},
 	"traditions-next": {
 		"message": "下個傳統"
 	},

--- a/en_src_messages.json
+++ b/en_src_messages.json
@@ -107,35 +107,35 @@
     "description": "Name of a country. This appears as a label in a geography game.",
     "message": "Bhutan"
   },
-  "buildandbolt-build-car-multiple" : {
+  "buildandbolt-build-car-multiple": {
     "description": "Message telling the player the quantity and type of toy they need to make.",
     "raw": "Build <ph name=\"COUNT\"><ex>3</ex>{{count}}</ph> cars!"
   },
-  "buildandbolt-build-car-single" : {
+  "buildandbolt-build-car-single": {
     "description": "Message telling the player the quantity and type of toy they need to make.",
     "raw": "Build 1 car!"
   },
-  "buildandbolt-build-robot-multiple" : {
+  "buildandbolt-build-robot-multiple": {
     "description": "Message telling the player the quantity and type of toy they need to make.",
     "raw": "Build <ph name=\"COUNT\"><ex>3</ex>{{count}}</ph> robots!"
   },
-  "buildandbolt-build-robot-single" : {
+  "buildandbolt-build-robot-single": {
     "description": "Message telling the player the quantity and type of toy they need to make.",
     "raw": "Build 1 robot!"
   },
-  "buildandbolt-build-teddybear-multiple" : {
+  "buildandbolt-build-teddybear-multiple": {
     "description": "Message telling the player the quantity and type of toy they need to make.",
     "raw": "Build <ph name=\"COUNT\"><ex>3</ex>{{count}}</ph> teddy bears!"
   },
-  "buildandbolt-build-teddybear-single" : {
+  "buildandbolt-build-teddybear-single": {
     "description": "Message telling the player the quantity and type of toy they need to make.",
     "raw": "Build 1 teddy bear!"
   },
-  "buildandbolt-build-rocket-multiple" : {
+  "buildandbolt-build-rocket-multiple": {
     "description": "Message telling the player the quantity and type of toy they need to make.",
     "raw": "Build <ph name=\"COUNT\"><ex>3</ex>{{count}}</ph> rockets!"
   },
-  "buildandbolt-build-rocket-single" : {
+  "buildandbolt-build-rocket-single": {
     "description": "Message telling the player the quantity and type of toy they need to make.",
     "raw": "Build 1 rocket!"
   },
@@ -4740,6 +4740,14 @@
   "tracker_your_location": {
     "description": "Heading where the location of the user is displayed below",
     "message": "Your location"
+  },
+  "tracker_santa_is_at": {
+    "description": "Describes Santa's current location when he is at a stop. {{location}} is the city and region name.",
+    "message": "Santa Claus is at {{location}}"
+  },
+  "tracker_santa_is_heading_to": {
+    "description": "Describes Santa's destination when he is traveling. {{location}} is the city and region name.",
+    "message": "Santa Claus is heading to {{location}}"
   },
   "traditions-next": {
     "description": "Button text. Please keep short. User can move through a set of cards describing local traditions of a country.",

--- a/en_src_messages.json
+++ b/en_src_messages.json
@@ -4710,6 +4710,14 @@
     "description": "Heading above the next stop for Santa",
     "message": "Next stop"
   },
+  "tracker_santa_is_at": {
+    "description": "Describes Santa's current location when he is at a stop. {{location}} is the city and region name.",
+    "message": "Santa Claus is at {{location}}"
+  },
+  "tracker_santa_is_heading_to": {
+    "description": "Describes Santa's destination when he is traveling. {{location}} is the city and region name.",
+    "message": "Santa Claus is heading to {{location}}"
+  },
   "tracker_santa_update": {
     "message": "SANTA UPDATE"
   },
@@ -4740,14 +4748,6 @@
   "tracker_your_location": {
     "description": "Heading where the location of the user is displayed below",
     "message": "Your location"
-  },
-  "tracker_santa_is_at": {
-    "description": "Describes Santa's current location when he is at a stop. {{location}} is the city and region name.",
-    "message": "Santa Claus is at {{location}}"
-  },
-  "tracker_santa_is_heading_to": {
-    "description": "Describes Santa's destination when he is traveling. {{location}} is the city and region name.",
-    "message": "Santa Claus is heading to {{location}}"
   },
   "traditions-next": {
     "description": "Button text. Please keep short. User can move through a set of cards describing local traditions of a country.",

--- a/static/scenes/modvil/elements/modvil-tracker.js
+++ b/static/scenes/modvil/elements/modvil-tracker.js
@@ -48,7 +48,7 @@ const routeJitterRatio = +localStorage['routeJitter'] || 0;
 
 
 class ModvilTrackerElement extends LitElement {
-  static get styles() { return [styles]; }
+  static get styles() {return [styles];}
 
   static get properties() {
     return {
@@ -197,6 +197,7 @@ class ModvilTrackerElement extends LitElement {
     const details = this._dataManager.details;
     this._santaOverlay.position = new google.maps.LatLng(details.location.lat, details.location.lng);
     this._santaNode.heading = details.heading;
+    this._santaNode.locationLabel = `${details.raw.city}, ${details.raw.region}`;
     this._santaNode.stop = details.stop;
     this._santaNode.hidden = details.home;
     this._details = details;

--- a/static/src/elements/santa-santa.js
+++ b/static/src/elements/santa-santa.js
@@ -68,11 +68,8 @@ class SantaSantaElement extends LitElement {
 
     let label = _msg`santasearch_character_santa`;
     if (this.locationLabel) {
-      if (this.stop) {
-        label = label + ` is at ${this.locationLabel}`;
-      } else {
-        label = label + ` is heading to ${this.locationLabel}`;
-      }
+      const msgId = this.stop ? 'tracker_santa_is_at' : 'tracker_santa_is_heading_to';
+      label = _msg(msgId).replace('{{location}}', this.locationLabel);
     }
 
     return html`

--- a/static/src/elements/santa-santa.js
+++ b/static/src/elements/santa-santa.js
@@ -52,11 +52,12 @@ common.preload.assets(...urls.map((raw) => `${assetRoot}/${raw}`));
 
 
 class SantaSantaElement extends LitElement {
-  static get styles() { return [styles]; }
+  static get styles() {return [styles];}
 
   static get properties() {
     return {
       heading: {type: Number},
+      locationLabel: {type: String},
       stop: {type: Boolean},
     };
   }
@@ -64,9 +65,19 @@ class SantaSantaElement extends LitElement {
   render() {
     const dir = dirForHeading(this.heading);
     const mode = Math.floor(Math.abs(this.heading) % 2);  // could be decimal
+
+    let label = _msg`santasearch_character_santa`;
+    if (this.locationLabel) {
+      if (this.stop) {
+        label = label + ` is at ${this.locationLabel}`;
+      } else {
+        label = label + ` is heading to ${this.locationLabel}`;
+      }
+    }
+
     return html`
 <div id="outer">
-  <button>${_msg`santasearch_character_santa`}</button>
+  <button>${label}</button>
   <div class="presents mode${mode}" ?hidden=${!this.stop}></div>
   <div class="sleigh" data-dir=${dir} ?hidden=${this.stop}>
     <div class="back"></div>


### PR DESCRIPTION
This PR fixes an accessibility issue where the "Santa image" button only announced "Santa Claus" without providing context about his current location or status. Screen reader users would land on the button but receive no useful information about where Santa currently is in the world.

### Changes
* **Dynamic Location Announcement**: Updated `SantaSantaElement` to accept a locationLabel property and dynamically update the button text.
* **Contextual Phrasing**: Implemented logic to distinguish between Santa's states: 
  * "Santa Claus is at [Location]" when stopped.
  * "Santa Claus is heading to [Location]" when moving.
* **Data Integration**: Modified `ModvilTrackerElement` to extract the city and region from the data manager and pass it correctly to the `santa-santa` component.
* **Localization Support**: Added new message keys `tracker_santa_is_at` and `tracker_santa_is_heading_to` with `{{location}}` placeholders to ensure proper grammar and translation across languages.
* **Multi-locale Support**: Added and ordered translations for `en`, `en-GB`, `zh-CN`, `zh-TW`, `zh-HK`, `ja`, and `ko`.

### Impacted UI components
* Santa Tracker Map (`modvil-tracker`)
* Santa Agent (`santa-santa`)
