### PR TITLE
Fix Present Drop bug #209 by removing self closing tags from Chimney markup.

### DIFF
--- a/static/scenes/presentdrop/js/chimney.js
+++ b/static/scenes/presentdrop/js/chimney.js
@@ -26,13 +26,19 @@ goog.require('app.shared.pools');
  */
 app.Chimney = function(game) {
   this.game = game;
-  this.elem = $('<div class="train hidden">' +
-      '<div class="flag"><div class="flag-stick"/><div class="flag-score"/></div>' +
-      '<div class="handle" />' +
-      '<div class="hand" />' +
-      '<div class="chimney" />' +
-      '<div class="wheel1" />' +
-      '<div class="wheel2" /></div>');
+  this.elem = $(`
+    <div class="train hidden">
+      <div class="flag">
+        <div class="flag-stick"></div>
+        <div class="flag-score"></div>
+      </div>
+      <div class="handle"></div>
+      <div class="hand"></div>
+      <div class="chimney"></div>
+      <div class="wheel1"></div>
+      <div class="wheel2"></div>
+    </div>
+  `);
   game.chimneysElem.append(this.elem);
 
   this.dead = false;


### PR DESCRIPTION
Here is a screenshot of the game in OSX chrome with the fix applied. I was able to reproduce the error in the same context before applying the fix:
<img width="867" height="629" alt="Screenshot 2026-01-07 at 10 32 47 AM" src="https://github.com/user-attachments/assets/6558f0a9-6247-401d-a716-eb240e4f7865" />
