### PR TITLE
Improve dev server script for playwright tests

### DIFF
--- a/build/compile-scene.js
+++ b/build/compile-scene.js
@@ -93,12 +93,19 @@ function invokeCompiler(compiler) {
 }
 
 
+const sceneCache = new Map();
+
 /**
  * @param {string} sceneName
  * @param {boolean=} compile
+ * @param {boolean=} cache
  * @return {{code: string, map: !Object}}
  */
-module.exports = async function compile(sceneName, compile=true) {
+module.exports = async function compile(sceneName, compile=true, cache=false) {
+  const cacheKey = `${sceneName}-${compile}`;
+  if (cache && sceneCache.has(cacheKey)) {
+    return sceneCache.get(cacheKey);
+  }
   const compilerSrc = [
     'build/transpile/export.js',
     'static/scenes/_shared/js',
@@ -171,7 +178,11 @@ module.exports = async function compile(sceneName, compile=true) {
     map.sources.push(`static/scenes/${sceneName}/js`, `static/scenes/_shared/js`);
     map.sourcesContent.push(null, null);
 
-    return {code, map};
+    const result = {code, map};
+    if (cache) {
+      sceneCache.set(cacheKey, result);
+    }
+    return result;
   } finally {
     sourceMapTemp.removeCallback();
   }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,6 +1,8 @@
 const { defineConfig, devices } = require('@playwright/test');
 
-const baseURL = process.env.BASE_URL || 'http://localhost:8000';
+const baseURL = process.env.BASE_URL || `http://localhost:${process.env.PORT || 8005}`;
+const urlObj = new URL(baseURL);
+const port = process.env.PORT || urlObj.port || 8005;
 const isLocal = baseURL.includes('localhost') || baseURL.includes('127.0.0.1');
 
 module.exports = defineConfig({
@@ -26,7 +28,7 @@ module.exports = defineConfig({
   ],
   webServer: isLocal
     ? {
-        command: `node ./serve.js --cache`,
+        command: `node ./serve.js --port ${port} --cache`,
         url: baseURL,
         reuseExistingServer: !process.env.CI,
         timeout: 120 * 1000,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -26,8 +26,8 @@ module.exports = defineConfig({
   ],
   webServer: isLocal
     ? {
-        command: 'npm start',
-        url: 'http://localhost:8000',
+        command: `node ./serve.js --cache`,
+        url: baseURL,
         reuseExistingServer: !process.env.CI,
         timeout: 120 * 1000,
       }

--- a/santa-vfs.js
+++ b/santa-vfs.js
@@ -130,6 +130,7 @@ module.exports = (staticScope, options) => {
   options = Object.assign({
     lang: null,
     compile: true,
+    cache: false,
     config: {},
   }, options);
 
@@ -193,7 +194,7 @@ module.exports = (staticScope, options) => {
         throw new Error(`unsupported Closure flags: ${flags}`);
       }
 
-      const {code, map} = await compileScene(sceneName, options.compile);
+      const {code, map} = await compileScene(sceneName, options.compile, options.cache);
       return {code, map};
     },
   };

--- a/serve.js
+++ b/serve.js
@@ -63,6 +63,11 @@ const yargs = require('yargs')
       default: true,
       describe: 'Compile Closure scenes',
     })
+    .option('cache', {
+      type: 'boolean',
+      default: false,
+      describe: 'Cache compiled Closure scenes in memory',
+    })
     .argv;
 
 /**
@@ -106,6 +111,7 @@ const config = {
 async function serve() {
   const vfs = santaVfs(config.staticScope, {
     compile: yargs.compile,
+    cache: yargs.cache,
     lang: yargs.lang,
     config,
   });

--- a/serve.js
+++ b/serve.js
@@ -35,7 +35,10 @@ const yargs = require('yargs')
     .option('port', {
       alias: 'p',
       type: 'number',
-      default: process.env.PORT || 8000,
+      default: Number(process.env.PORT) || 8000,
+      coerce(v) {
+        return Number(v) || 8000;
+      },
       describe: 'Static port',
     })
     .option('all', {

--- a/tests/boatload.spec.js
+++ b/tests/boatload.spec.js
@@ -2,10 +2,7 @@ const { test, expect } = require('@playwright/test');
 const { expectGameOverOverlay } = require('./helpers');
 
 function getHostUrl(baseURL) {
-  if (baseURL && !baseURL.includes('localhost') && !baseURL.includes('127.0.0.1')) {
-    return `${baseURL}/boatload.html`;
-  }
-  return 'http://localhost:8000/boatload.html';
+  return `${baseURL || 'http://localhost:8000'}/boatload.html`;
 }
 
 async function advanceTime(page, seconds) {

--- a/tests/runner.spec.js
+++ b/tests/runner.spec.js
@@ -2,10 +2,7 @@ const { test, expect } = require('@playwright/test');
 const { expectGameOverOverlay } = require('./helpers');
 
 function getHostUrl(baseURL) {
-  if (baseURL && !baseURL.includes('localhost') && !baseURL.includes('127.0.0.1')) {
-    return `${baseURL}/runner.html`;
-  }
-  return 'http://localhost:8000/runner.html';
+  return `${baseURL || 'http://localhost:8000'}/runner.html`;
 }
 
 async function advanceTime(page, seconds) {


### PR DESCRIPTION
Tweaks to improve the performance and to allow for tests to run in parallel with dev servers and with other tests better:

- Allow port to be specified
- Add caching to avoid unnecessary recompiles from the dev server during tests.